### PR TITLE
Faster date parsing for most cases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dateutil==2.1
 six==1.3.0
 wsgiref==0.1.2
+pytz==2013d

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ for ir in parse_requirements("requirements.txt", options=opts):
 
 setup(
     name='vertica-python',
-    version='0.1.3',
+    version='0.1.4',
     description='A native Python client for the Vertica database.',
     author='Justin Berka',
     author_email='justin@uber.com',

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -2,7 +2,40 @@ from __future__ import absolute_import
 
 from decimal import Decimal
 from datetime import date
+from datetime import datetime
 from dateutil import parser
+import pytz
+
+
+# these methods are bad...
+#
+# a few timestamp with tz examples:
+# 2013-01-01 00:00:00
+# 2013-01-01 00:00:00+00
+# 2013-01-01 00:00:00.01+00
+# 2013-01-01 00:00:00.00001+00
+#
+# Vertica stores all data in UTC: 
+#   "TIMESTAMP WITH TIMEZONE (TIMESTAMPTZ) data is stored in GMT (UTC) by converting data from the current local time zone to GMT."
+# Vertica fetches data in local timezone:
+#   "When TIMESTAMPTZ data is used, data is converted back to use the current local time zone"
+# If vertica boxes are on UTC, you should never have a non +00 offset (as far as i can tell)
+#   ie. inserting '2013-01-01 00:00:00.01 EST' to a timestamptz type stores: 2013-01-01 05:00:00.01+00
+#       select t AT TIMEZONE 'America/New_York' returns: 2012-12-31 19:00:00.01
+def timestamp_parse(s):
+    if len(s) == 19:
+        return datetime.strptime(s, '%Y-%m-%d %H:%M:%S')
+    return datetime.strptime(s, '%Y-%m-%d %H:%M:%S.%f')
+
+def timestamp_tz_parse(s):
+    # if timezome is simply UTC...
+    if s.endswith('+00'):
+        # remove time zone
+        ts = timestamp_parse(s[:-3])
+        ts = ts.replace(tzinfo=pytz.UTC)
+        return ts
+    # other wise do a real parse (slower)
+    return parser.parse(s)
 
 class Column(object):
 
@@ -19,8 +52,8 @@ class Column(object):
         ['varchar', lambda s: unicode(s, 'utf-8')],
         ['date', lambda s: date(*map(lambda x: int(x), s.split('-')))],
         ['time', None],
-        ['timestamp', lambda s: parser.parse(s)],
-        ['timestamp_tz', lambda s: parser.parse(s)],
+        ['timestamp', timestamp_parse],
+        ['timestamp_tz', timestamp_tz_parse],
         ['interval', None],
         ['time_tz', None],
         ['numeric', lambda s: Decimal(s)],


### PR DESCRIPTION
dateutil is quite a bit slower than datetime.strptime.
However %z directive (timezone) doesn't seem to exist.
Started down the road of implementing a timezone parser logic, but then decided against it. This diff only uses strptime for datetime without timezone and UTC timezone.
