### PR TITLE
Add extras_require for namedparams.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     packages=find_packages(),
     license="MIT",
     install_requires=install_requires,
+    extras_require={'namedparams': ['psycopg2>=2.5.1']},
     dependency_links=dependency_links,
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Testing done:

```
% python setup.py sdist 
running sdist
running egg_info
creating vertica_python.egg-info
writing requirements to vertica_python.egg-info/requires.txt
writing vertica_python.egg-info/PKG-INFO
writing top-level names to vertica_python.egg-info/top_level.txt
writing dependency_links to vertica_python.egg-info/dependency_links.txt
writing manifest file 'vertica_python.egg-info/SOURCES.txt'
reading manifest file 'vertica_python.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '*.pyc' found under directory 'vertica_python'
writing manifest file 'vertica_python.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt

running check
creating vertica-python-0.2.1
creating vertica-python-0.2.1/vertica_python
creating vertica-python-0.2.1/vertica_python.egg-info
creating vertica-python-0.2.1/vertica_python/vertica
creating vertica-python-0.2.1/vertica_python/vertica/messages
creating vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
creating vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
making hard links in vertica-python-0.2.1...
hard linking LICENSE -> vertica-python-0.2.1
hard linking MANIFEST.in -> vertica-python-0.2.1
hard linking README.md -> vertica-python-0.2.1
hard linking requirements.txt -> vertica-python-0.2.1
hard linking setup.py -> vertica-python-0.2.1
hard linking vertica_python/__init__.py -> vertica-python-0.2.1/vertica_python
hard linking vertica_python/datatypes.py -> vertica-python-0.2.1/vertica_python
hard linking vertica_python/errors.py -> vertica-python-0.2.1/vertica_python
hard linking vertica_python.egg-info/PKG-INFO -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/SOURCES.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/dependency_links.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/requires.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/top_level.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python/vertica/__init__.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/column.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/connection.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/cursor.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/messages/__init__.py -> vertica-python-0.2.1/vertica_python/vertica/messages
hard linking vertica_python/vertica/messages/message.py -> vertica-python-0.2.1/vertica_python/vertica/messages
hard linking vertica_python/vertica/messages/backend_messages/__init__.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/authentication.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/backend_key_data.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/bind_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/close_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/command_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/copy_in_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/data_row.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/empty_query_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/error_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/no_data.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/notice_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/parameter_description.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/parameter_status.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/parse_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/portal_suspended.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/ready_for_query.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/row_description.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/unknown.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/frontend_messages/__init__.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/bind.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/cancel_request.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/close.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/copy_data.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/copy_done.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/copy_fail.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/describe.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/execute.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/flush.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/parse.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/password.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/query.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/ssl_request.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/startup.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/sync.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/terminate.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
Writing vertica-python-0.2.1/setup.cfg
creating dist
Creating tar archive
```

Without extras:

```
~ % virtualenv vertica
New python executable in vertica/bin/python
Installing setuptools, pip...done.
~ % source vertica/bin/activate
(vertica)~ % pip install -f workspace/vertica-python/dist 'vertica-python'             
Downloading/unpacking vertica-python
  Running setup.py (path:/home/ksweeney/vertica/build/vertica-python/setup.py) egg_info for package vertica-python

    warning: no previously-included files matching '*.pyc' found under directory 'vertica_python'
Downloading/unpacking python-dateutil>=1.5 (from vertica-python)
  Downloading python-dateutil-2.2.tar.gz (259kB): 259kB downloaded
  Running setup.py (path:/home/ksweeney/vertica/build/python-dateutil/setup.py) egg_info for package python-dateutil

Downloading/unpacking pytz (from vertica-python)
  Downloading pytz-2014.2.tar.bz2 (160kB): 160kB downloaded
  Running setup.py (path:/home/ksweeney/vertica/build/pytz/setup.py) egg_info for package pytz

Downloading/unpacking six (from python-dateutil>=1.5->vertica-python)
  Downloading six-1.6.1-py2.py3-none-any.whl
Installing collected packages: vertica-python, python-dateutil, pytz, six
  Running setup.py install for vertica-python

    warning: no previously-included files matching '*.pyc' found under directory 'vertica_python'
  Running setup.py install for python-dateutil

  Running setup.py install for pytz

Successfully installed vertica-python python-dateutil pytz six
Cleaning up...
```

With extras:

```
~ % virtualenv vertica
New python executable in vertica/bin/python
Installing setuptools, pip...done.
~ % source vertica/bin/activate
(vertica)~ % pip install -f workspace/vertica-python/dist 'vertica-python[namedparams]'
Downloading/unpacking vertica-python[namedparams]
  Running setup.py (path:/home/ksweeney/vertica/build/vertica-python/setup.py) egg_info for package vertica-python

    warning: no previously-included files matching '*.pyc' found under directory 'vertica_python'
  Installing extra requirements: 'namedparams'
Downloading/unpacking python-dateutil>=1.5 (from vertica-python[namedparams])
  Downloading python-dateutil-2.2.tar.gz (259kB): 259kB downloaded
  Running setup.py (path:/home/ksweeney/vertica/build/python-dateutil/setup.py) egg_info for package python-dateutil

Downloading/unpacking pytz (from vertica-python[namedparams])
  Downloading pytz-2014.2.tar.bz2 (160kB): 160kB downloaded
  Running setup.py (path:/home/ksweeney/vertica/build/pytz/setup.py) egg_info for package pytz

Downloading/unpacking psycopg2>=2.5.1 (from vertica-python[namedparams])
  Downloading psycopg2-2.5.2.tar.gz (685kB): 685kB downloaded
  Running setup.py (path:/home/ksweeney/vertica/build/psycopg2/setup.py) egg_info for package psycopg2

Downloading/unpacking six (from python-dateutil>=1.5->vertica-python[namedparams])
  Downloading six-1.6.1-py2.py3-none-any.whl
Installing collected packages: vertica-python, python-dateutil, pytz, psycopg2, six
  Running setup.py install for vertica-python

    warning: no previously-included files matching '*.pyc' found under directory 'vertica_python'
  Running setup.py install for python-dateutil

  Running setup.py install for pytz

  Running setup.py install for psycopg2
    building 'psycopg2._psycopg' extension
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/psycopgmodule.c -o build/temp.linux-x86_64-2.7/psycopg/psycopgmodule.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/green.c -o build/temp.linux-x86_64-2.7/psycopg/green.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/pqpath.c -o build/temp.linux-x86_64-2.7/psycopg/pqpath.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/utils.c -o build/temp.linux-x86_64-2.7/psycopg/utils.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/bytes_format.c -o build/temp.linux-x86_64-2.7/psycopg/bytes_format.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/connection_int.c -o build/temp.linux-x86_64-2.7/psycopg/connection_int.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/connection_type.c -o build/temp.linux-x86_64-2.7/psycopg/connection_type.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/cursor_int.c -o build/temp.linux-x86_64-2.7/psycopg/cursor_int.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/cursor_type.c -o build/temp.linux-x86_64-2.7/psycopg/cursor_type.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/diagnostics_type.c -o build/temp.linux-x86_64-2.7/psycopg/diagnostics_type.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/error_type.c -o build/temp.linux-x86_64-2.7/psycopg/error_type.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/lobject_int.c -o build/temp.linux-x86_64-2.7/psycopg/lobject_int.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/lobject_type.c -o build/temp.linux-x86_64-2.7/psycopg/lobject_type.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/notify_type.c -o build/temp.linux-x86_64-2.7/psycopg/notify_type.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/xid_type.c -o build/temp.linux-x86_64-2.7/psycopg/xid_type.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_asis.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_asis.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_binary.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_binary.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_datetime.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_datetime.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_list.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_list.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_pboolean.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_pboolean.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_pdecimal.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_pdecimal.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_pint.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_pint.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_pfloat.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_pfloat.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/adapter_qstring.c -o build/temp.linux-x86_64-2.7/psycopg/adapter_qstring.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/microprotocols.c -o build/temp.linux-x86_64-2.7/psycopg/microprotocols.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/microprotocols_proto.c -o build/temp.linux-x86_64-2.7/psycopg/microprotocols_proto.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fPIC -DPSYCOPG_DEFAULT_PYDATETIME=1 -DPSYCOPG_VERSION="2.5.2 (dt dec pq3 ext)" -DPG_VERSION_HEX=0x090304 -DPSYCOPG_EXTENSIONS=1 -DPSYCOPG_NEW_BOOLEAN=1 -DHAVE_PQFREEMEM=1 -I/usr/include/python2.7 -I. -I/usr/include/postgresql -I/usr/include/postgresql/9.3/server -c psycopg/typecast.c -o build/temp.linux-x86_64-2.7/psycopg/typecast.o -Wdeclaration-after-statement
    x86_64-linux-gnu-gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -Wl,-Bsymbolic-functions -Wl,-z,relro -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -D_FORTIFY_SOURCE=2 -g -fstack-protector --param=ssp-buffer-size=4 -Wformat -Werror=format-security build/temp.linux-x86_64-2.7/psycopg/psycopgmodule.o build/temp.linux-x86_64-2.7/psycopg/green.o build/temp.linux-x86_64-2.7/psycopg/pqpath.o build/temp.linux-x86_64-2.7/psycopg/utils.o build/temp.linux-x86_64-2.7/psycopg/bytes_format.o build/temp.linux-x86_64-2.7/psycopg/connection_int.o build/temp.linux-x86_64-2.7/psycopg/connection_type.o build/temp.linux-x86_64-2.7/psycopg/cursor_int.o build/temp.linux-x86_64-2.7/psycopg/cursor_type.o build/temp.linux-x86_64-2.7/psycopg/diagnostics_type.o build/temp.linux-x86_64-2.7/psycopg/error_type.o build/temp.linux-x86_64-2.7/psycopg/lobject_int.o build/temp.linux-x86_64-2.7/psycopg/lobject_type.o build/temp.linux-x86_64-2.7/psycopg/notify_type.o build/temp.linux-x86_64-2.7/psycopg/xid_type.o build/temp.linux-x86_64-2.7/psycopg/adapter_asis.o build/temp.linux-x86_64-2.7/psycopg/adapter_binary.o build/temp.linux-x86_64-2.7/psycopg/adapter_datetime.o build/temp.linux-x86_64-2.7/psycopg/adapter_list.o build/temp.linux-x86_64-2.7/psycopg/adapter_pboolean.o build/temp.linux-x86_64-2.7/psycopg/adapter_pdecimal.o build/temp.linux-x86_64-2.7/psycopg/adapter_pint.o build/temp.linux-x86_64-2.7/psycopg/adapter_pfloat.o build/temp.linux-x86_64-2.7/psycopg/adapter_qstring.o build/temp.linux-x86_64-2.7/psycopg/microprotocols.o build/temp.linux-x86_64-2.7/psycopg/microprotocols_proto.o build/temp.linux-x86_64-2.7/psycopg/typecast.o -lpq -o build/lib.linux-x86_64-2.7/psycopg2/_psycopg.so

Successfully installed vertica-python python-dateutil pytz psycopg2 six
Cleaning up...
(vertica)~ % deactivate 
~ % rm -fr vertica
```
