### PR TITLE
Remove pip dependency from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,10 @@
 import collections
 from setuptools import setup, find_packages
 
-from pip.req import parse_requirements
-
-dependency_links = []
-install_requires = []
 
 ReqOpts = collections.namedtuple('ReqOpts', ['skip_requirements_regex', 'default_vcs'])
 
 opts = ReqOpts(None, 'git')
-
-for ir in parse_requirements("requirements.txt", options=opts):
-    if ir is not None:
-        if ir.url is not None:
-            dependency_links.append(str(ir.url))
-        if ir.req is not None:
-            install_requires.append(str(ir.req))
 
 setup(
     name='vertica-python',
@@ -28,9 +17,8 @@ setup(
     keywords="database vertica",
     packages=find_packages(),
     license="MIT",
-    install_requires=install_requires,
+    install_requires=['python-dateutil>=1.5', 'pytz'],
     extras_require={'namedparams': ['psycopg2>=2.5.1']},
-    dependency_links=dependency_links,
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",


### PR DESCRIPTION
This fixes #27.

Testing done:

sdist can still be created

```
~/workspace/vertica-python git vertica-python/. master    
% python setup.py sdist
running sdist
running egg_info
creating vertica_python.egg-info
writing requirements to vertica_python.egg-info/requires.txt
writing vertica_python.egg-info/PKG-INFO
writing top-level names to vertica_python.egg-info/top_level.txt
writing dependency_links to vertica_python.egg-info/dependency_links.txt
writing manifest file 'vertica_python.egg-info/SOURCES.txt'
reading manifest file 'vertica_python.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no previously-included files matching '*.pyc' found under directory 'vertica_python'
writing manifest file 'vertica_python.egg-info/SOURCES.txt'
warning: sdist: standard file not found: should have one of README, README.rst, README.txt

running check
creating vertica-python-0.2.1
creating vertica-python-0.2.1/vertica_python
creating vertica-python-0.2.1/vertica_python.egg-info
creating vertica-python-0.2.1/vertica_python/vertica
creating vertica-python-0.2.1/vertica_python/vertica/messages
creating vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
creating vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
making hard links in vertica-python-0.2.1...
hard linking LICENSE -> vertica-python-0.2.1
hard linking MANIFEST.in -> vertica-python-0.2.1
hard linking README.md -> vertica-python-0.2.1
hard linking requirements.txt -> vertica-python-0.2.1
hard linking setup.py -> vertica-python-0.2.1
hard linking vertica_python/__init__.py -> vertica-python-0.2.1/vertica_python
hard linking vertica_python/datatypes.py -> vertica-python-0.2.1/vertica_python
hard linking vertica_python/errors.py -> vertica-python-0.2.1/vertica_python
hard linking vertica_python.egg-info/PKG-INFO -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/SOURCES.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/dependency_links.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/requires.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python.egg-info/top_level.txt -> vertica-python-0.2.1/vertica_python.egg-info
hard linking vertica_python/vertica/__init__.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/column.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/connection.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/cursor.py -> vertica-python-0.2.1/vertica_python/vertica
hard linking vertica_python/vertica/messages/__init__.py -> vertica-python-0.2.1/vertica_python/vertica/messages
hard linking vertica_python/vertica/messages/message.py -> vertica-python-0.2.1/vertica_python/vertica/messages
hard linking vertica_python/vertica/messages/backend_messages/__init__.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/authentication.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/backend_key_data.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/bind_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/close_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/command_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/copy_in_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/data_row.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/empty_query_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/error_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/no_data.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/notice_response.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/parameter_description.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/parameter_status.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/parse_complete.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/portal_suspended.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/ready_for_query.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/row_description.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/backend_messages/unknown.py -> vertica-python-0.2.1/vertica_python/vertica/messages/backend_messages
hard linking vertica_python/vertica/messages/frontend_messages/__init__.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/bind.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/cancel_request.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/close.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/copy_data.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/copy_done.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/copy_fail.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/describe.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/execute.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/flush.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/parse.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/password.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/query.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/ssl_request.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/startup.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/sync.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
hard linking vertica_python/vertica/messages/frontend_messages/terminate.py -> vertica-python-0.2.1/vertica_python/vertica/messages/frontend_messages
Writing vertica-python-0.2.1/setup.cfg
creating dist
Creating tar archive
removing 'vertica-python-0.2.1' (and everything under it)
```

twitter.common.python can build a .pex with vertica-python and its dependencies

```
~/workspace/vertica-python git vertica-python/. master    
% ../aurora/build-support/pex --repo dist -r vertica-python -o vertica-python.pex
~/workspace/vertica-python git vertica-python/. master    
% zipinfo -l vertica-python.pex 
Archive:  vertica-python.pex
Zip file size: 857872 bytes, number of entries: 710
-rw-rw-r--  2.0 unx      552 b-      250 defN 14-May-20 11:05 .bootstrap/_markerlib/__init__.py
-rw-rw-r--  2.0 unx     1347 b-      531 defN 14-May-20 11:05 .bootstrap/_markerlib/__init__.pyc
-rw-rw-r--  2.0 unx     3979 b-     1478 defN 14-May-20 11:05 .bootstrap/_markerlib/markers.py
-rw-rw-r--  2.0 unx     5713 b-     2217 defN 14-May-20 11:05 .bootstrap/_markerlib/markers.pyc
-rw-rw-r--  2.0 unx      901 b-      389 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/__init__.py
-rw-rw-r--  2.0 unx      998 b-      398 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/base.py
-rw-rw-r--  2.0 unx     9266 b-     3017 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/common.py
-rw-rw-r--  2.0 unx     2589 b-     1028 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/compatibility.py
-rw-rw-r--  2.0 unx     6213 b-     2057 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/environment.py
-rw-rw-r--  2.0 unx     1402 b-      656 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/fetcher.py
-rw-rw-r--  2.0 unx     8518 b-     2814 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/finders.py
-rw-rw-r--  2.0 unx      134 b-       90 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/http/__init__.py
-rw-rw-r--  2.0 unx     4933 b-     1832 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/http/crawler.py
-rw-rw-r--  2.0 unx     7235 b-     2433 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/http/http.py
-rw-rw-r--  2.0 unx     2115 b-      783 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/http/link.py
-rw-rw-r--  2.0 unx      182 b-      144 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/http/tracer.py
-rw-rw-r--  2.0 unx     8500 b-     2588 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/installer.py
-rw-rw-r--  2.0 unx    13139 b-     3957 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/interpreter.py
-rw-rw-r--  2.0 unx     2264 b-      773 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/marshaller.py
-rw-rw-r--  2.0 unx     5796 b-     1791 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/obtainer.py
-rw-rw-r--  2.0 unx     2888 b-     1116 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/orderedset.py
-rw-rw-r--  2.0 unx     9291 b-     2787 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/package.py
-rw-rw-r--  2.0 unx     4848 b-     1682 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/pep425.py
-rw-rw-r--  2.0 unx    11401 b-     3726 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/pex.py
-rw-rw-r--  2.0 unx     1831 b-      653 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/pex_bootstrapper.py
-rw-rw-r--  2.0 unx     9605 b-     3247 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/pex_builder.py
-rw-rw-r--  2.0 unx     6651 b-     1984 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/pex_info.py
-rw-rw-r--  2.0 unx     3230 b-     1100 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/platforms.py
-rw-rw-r--  2.0 unx     4289 b-     1379 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/resolver.py
-rw-rw-r--  2.0 unx     3115 b-     1138 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/testing.py
-rw-rw-r--  2.0 unx     3996 b-     1359 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/tracer.py
-rw-rw-r--  2.0 unx     6087 b-     1696 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/translator.py
-rw-rw-r--  2.0 unx     5289 b-     1778 defN 14-May-20 11:05 .bootstrap/_twitter_common_python/util.py
-rw-rw-r--  2.0 unx   100142 b-    27557 defN 14-May-20 11:05 .bootstrap/pkg_resources.py
-rw-rw-r--  2.0 unx      278 b-      208 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/__init__.py
-rw-rw-r--  2.0 unx     2578 b-     1236 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/easter.py
-rw-rw-r--  2.0 unx    34280 b-     7045 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/parser.py
-rw-rw-r--  2.0 unx    17224 b-     3981 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/relativedelta.py
-rw-rw-r--  2.0 unx    41036 b-     8025 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/rrule.py
-rw-rw-r--  2.0 unx    32988 b-     7570 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/tz.py
-rw-rw-r--  2.0 unx     5737 b-     1587 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/tzwin.py
-rw-rw-r--  2.0 unx     3558 b-     1376 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/zoneinfo/__init__.py
-rw-rw-r--  2.0 unx   198578 b-   191761 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/dateutil/zoneinfo/zoneinfo--latest.tar.gz
-rw-rw-r--  2.0 unx      117 b-       94 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/python_dateutil-2.2.dist-info/DESCRIPTION.rst
-rw-rw-r--  2.0 unx      962 b-      399 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/python_dateutil-2.2.dist-info/METADATA
-rw-rw-r--  2.0 unx     1252 b-      745 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/python_dateutil-2.2.dist-info/RECORD
-rw-rw-r--  2.0 unx       92 b-       92 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/python_dateutil-2.2.dist-info/WHEEL
-rw-rw-r--  2.0 unx      954 b-      451 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/python_dateutil-2.2.dist-info/metadata.json
-rw-rw-r--  2.0 unx        9 b-       11 defN 14-May-20 11:05 .deps/python_dateutil-2.2-py2-none-any.whl/python_dateutil-2.2.dist-info/top_level.txt
-rw-rw-r--  2.0 unx    24207 b-     6893 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/EGG-INFO/PKG-INFO
-rw-rw-r--  2.0 unx    17410 b-     3853 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/EGG-INFO/SOURCES.txt
-rw-rw-r--  2.0 unx        1 b-        3 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/EGG-INFO/dependency_links.txt
-rw-rw-r--  2.0 unx        5 b-        7 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/EGG-INFO/top_level.txt
-rw-rw-r--  2.0 unx        1 b-        3 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/EGG-INFO/zip-safe
-rw-rw-r--  2.0 unx    33936 b-     8086 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/__init__.py
-rw-rw-r--  2.0 unx    32451 b-    11519 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/__init__.pyc
-rw-rw-r--  2.0 unx     1333 b-      576 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/exceptions.py
-rw-rw-r--  2.0 unx     2029 b-      841 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/exceptions.pyc
-rw-rw-r--  2.0 unx     5263 b-     1136 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/lazy.py
-rw-rw-r--  2.0 unx     6488 b-     2161 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/lazy.pyc
-rw-rw-r--  2.0 unx     3649 b-     1323 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/reference.py
-rw-rw-r--  2.0 unx     4822 b-     1793 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/reference.pyc
-rw-rw-r--  2.0 unx     4869 b-     1752 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/tzfile.py
-rw-rw-r--  2.0 unx     3887 b-     1993 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/tzfile.pyc
-rw-rw-r--  2.0 unx    19212 b-     4813 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/tzinfo.py
-rw-rw-r--  2.0 unx    16680 b-     5293 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/tzinfo.pyc
-rw-rw-r--  2.0 unx      170 b-       54 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Abidjan
-rw-rw-r--  2.0 unx      392 b-      184 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Accra
-rw-rw-r--  2.0 unx      206 b-       82 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Addis_Ababa
-rw-rw-r--  2.0 unx      760 b-      366 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Algiers
-rw-rw-r--  2.0 unx      227 b-      110 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Asmara
-rw-rw-r--  2.0 unx      227 b-      110 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Asmera
-rw-rw-r--  2.0 unx      238 b-       83 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Bamako
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Bangui
-rw-rw-r--  2.0 unx      246 b-       90 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Banjul
-rw-rw-r--  2.0 unx      208 b-       74 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Bissau
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Blantyre
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Brazzaville
-rw-rw-r--  2.0 unx      149 b-       66 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Bujumbura
-rw-rw-r--  2.0 unx     2795 b-     1357 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Cairo
-rw-rw-r--  2.0 unx     1693 b-      832 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Casablanca
-rw-rw-r--  2.0 unx     2075 b-      982 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Ceuta
-rw-rw-r--  2.0 unx      238 b-       83 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Conakry
-rw-rw-r--  2.0 unx      208 b-       76 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Dakar
-rw-rw-r--  2.0 unx      243 b-       89 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Dar_es_Salaam
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Djibouti
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Douala
-rw-rw-r--  2.0 unx     1523 b-      742 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/El_Aaiun
-rw-rw-r--  2.0 unx      691 b-      341 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Freetown
-rw-rw-r--  2.0 unx      260 b-      105 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Gaborone
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Harare
-rw-rw-r--  2.0 unx      271 b-      117 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Johannesburg
-rw-rw-r--  2.0 unx      683 b-      327 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Juba
-rw-rw-r--  2.0 unx      283 b-      106 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Kampala
-rw-rw-r--  2.0 unx      683 b-      327 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Khartoum
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Kigali
-rw-rw-r--  2.0 unx      149 b-       66 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Kinshasa
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Lagos
-rw-rw-r--  2.0 unx      171 b-       57 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Libreville
-rw-rw-r--  2.0 unx      148 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Lome
-rw-rw-r--  2.0 unx      204 b-       82 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Luanda
-rw-rw-r--  2.0 unx      149 b-       66 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Lubumbashi
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Lusaka
-rw-rw-r--  2.0 unx      209 b-       73 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Malabo
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Maputo
-rw-rw-r--  2.0 unx      218 b-       84 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Maseru
-rw-rw-r--  2.0 unx      174 b-       59 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Mbabane
-rw-rw-r--  2.0 unx      236 b-       91 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Mogadishu
-rw-rw-r--  2.0 unx      241 b-       94 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Monrovia
-rw-rw-r--  2.0 unx      283 b-      107 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Nairobi
-rw-rw-r--  2.0 unx      225 b-       85 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Ndjamena
-rw-rw-r--  2.0 unx      239 b-       89 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Niamey
-rw-rw-r--  2.0 unx      238 b-       82 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Nouakchott
-rw-rw-r--  2.0 unx      170 b-       54 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Ouagadougou
-rw-rw-r--  2.0 unx      209 b-       73 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Porto-Novo
-rw-rw-r--  2.0 unx      195 b-       74 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Sao_Tome
-rw-rw-r--  2.0 unx      238 b-       83 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Timbuktu
-rw-rw-r--  2.0 unx      655 b-      331 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Tripoli
-rw-rw-r--  2.0 unx      710 b-      357 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Tunis
-rw-rw-r--  2.0 unx     1582 b-      750 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Africa/Windhoek
-rw-rw-r--  2.0 unx     2379 b-     1151 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Adak
-rw-rw-r--  2.0 unx     2384 b-     1150 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Anchorage
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Anguilla
-rw-rw-r--  2.0 unx      208 b-       79 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Antigua
-rw-rw-r--  2.0 unx      896 b-      437 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Araguaina
-rw-rw-r--  2.0 unx     1087 b-      538 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Buenos_Aires
-rw-rw-r--  2.0 unx     1129 b-      548 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Catamarca
-rw-rw-r--  2.0 unx     1129 b-      548 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/ComodRivadavia
-rw-rw-r--  2.0 unx     1129 b-      543 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Cordoba
-rw-rw-r--  2.0 unx     1145 b-      540 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Jujuy
-rw-rw-r--  2.0 unx     1143 b-      553 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/La_Rioja
-rw-rw-r--  2.0 unx     1173 b-      555 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Mendoza
-rw-rw-r--  2.0 unx     1129 b-      546 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Rio_Gallegos
-rw-rw-r--  2.0 unx     1101 b-      534 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Salta
-rw-rw-r--  2.0 unx     1143 b-      551 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/San_Juan
-rw-rw-r--  2.0 unx     1171 b-      559 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/San_Luis
-rw-rw-r--  2.0 unx     1157 b-      563 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Tucuman
-rw-rw-r--  2.0 unx     1129 b-      548 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Argentina/Ushuaia
-rw-rw-r--  2.0 unx      208 b-       78 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Aruba
-rw-rw-r--  2.0 unx     2062 b-      967 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Asuncion
-rw-rw-r--  2.0 unx      345 b-      150 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Atikokan
-rw-rw-r--  2.0 unx     2379 b-     1151 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Atka
-rw-rw-r--  2.0 unx     1036 b-      507 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Bahia
-rw-rw-r--  2.0 unx     1588 b-      758 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Bahia_Banderas
-rw-rw-r--  2.0 unx      344 b-      153 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Barbados
-rw-rw-r--  2.0 unx      588 b-      291 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Belem
-rw-rw-r--  2.0 unx      976 b-      479 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Belize
-rw-rw-r--  2.0 unx      307 b-      134 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Blanc-Sablon
-rw-rw-r--  2.0 unx      644 b-      318 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Boa_Vista
-rw-rw-r--  2.0 unx      257 b-      105 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Bogota
-rw-rw-r--  2.0 unx     2403 b-     1143 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Boise
-rw-rw-r--  2.0 unx     1087 b-      538 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Buenos_Aires
-rw-rw-r--  2.0 unx     2098 b-      993 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Cambridge_Bay
-rw-rw-r--  2.0 unx     2015 b-      976 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Campo_Grande
-rw-rw-r--  2.0 unx     1480 b-      709 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Cancun
-rw-rw-r--  2.0 unx      266 b-      112 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Caracas
-rw-rw-r--  2.0 unx     1129 b-      548 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Catamarca
-rw-rw-r--  2.0 unx      200 b-       76 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Cayenne
-rw-rw-r--  2.0 unx      203 b-       84 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Cayman
-rw-rw-r--  2.0 unx     3585 b-     1703 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Chicago
-rw-rw-r--  2.0 unx     1522 b-      729 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Chihuahua
-rw-rw-r--  2.0 unx      345 b-      150 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Coral_Harbour
-rw-rw-r--  2.0 unx     1129 b-      543 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Cordoba
-rw-rw-r--  2.0 unx      341 b-      157 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Costa_Rica
-rw-rw-r--  2.0 unx      233 b-       95 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Creston
-rw-rw-r--  2.0 unx     1987 b-      964 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Cuiaba
-rw-rw-r--  2.0 unx      208 b-       78 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Curacao
-rw-rw-r--  2.0 unx      714 b-      339 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Danmarkshavn
-rw-rw-r--  2.0 unx     2093 b-      998 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Dawson
-rw-rw-r--  2.0 unx     1059 b-      513 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Dawson_Creek
-rw-rw-r--  2.0 unx     2453 b-     1166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Denver
-rw-rw-r--  2.0 unx     2216 b-     1051 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Detroit
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Dominica
-rw-rw-r--  2.0 unx     2402 b-     1145 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Edmonton
-rw-rw-r--  2.0 unx      684 b-      329 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Eirunepe
-rw-rw-r--  2.0 unx      250 b-      107 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/El_Salvador
-rw-rw-r--  2.0 unx     2356 b-     1112 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Ensenada
-rw-rw-r--  2.0 unx     1675 b-      807 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Fort_Wayne
-rw-rw-r--  2.0 unx      728 b-      358 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Fortaleza
-rw-rw-r--  2.0 unx     2206 b-     1049 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Glace_Bay
-rw-rw-r--  2.0 unx     1877 b-      866 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Godthab
-rw-rw-r--  2.0 unx     3219 b-     1552 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Goose_Bay
-rw-rw-r--  2.0 unx     1897 b-      919 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Grand_Turk
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Grenada
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Guadeloupe
-rw-rw-r--  2.0 unx      306 b-      138 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Guatemala
-rw-rw-r--  2.0 unx      203 b-       83 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Guayaquil
-rw-rw-r--  2.0 unx      270 b-      105 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Guyana
-rw-rw-r--  2.0 unx     3438 b-     1631 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Halifax
-rw-rw-r--  2.0 unx     2437 b-     1157 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Havana
-rw-rw-r--  2.0 unx      454 b-      210 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Hermosillo
-rw-rw-r--  2.0 unx     1675 b-      807 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Indianapolis
-rw-rw-r--  2.0 unx     2437 b-     1166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Knox
-rw-rw-r--  2.0 unx     1731 b-      840 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Marengo
-rw-rw-r--  2.0 unx     1913 b-      940 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Petersburg
-rw-rw-r--  2.0 unx     1735 b-      831 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Tell_City
-rw-rw-r--  2.0 unx     1423 b-      689 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Vevay
-rw-rw-r--  2.0 unx     1703 b-      820 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Vincennes
-rw-rw-r--  2.0 unx     1787 b-      864 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indiana/Winamac
-rw-rw-r--  2.0 unx     1675 b-      807 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Indianapolis
-rw-rw-r--  2.0 unx     1928 b-      924 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Inuvik
-rw-rw-r--  2.0 unx     2046 b-      971 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Iqaluit
-rw-rw-r--  2.0 unx      507 b-      255 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Jamaica
-rw-rw-r--  2.0 unx     1145 b-      540 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Jujuy
-rw-rw-r--  2.0 unx     2362 b-     1143 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Juneau
-rw-rw-r--  2.0 unx     2781 b-     1323 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Kentucky/Louisville
-rw-rw-r--  2.0 unx     2361 b-     1132 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Kentucky/Monticello
-rw-rw-r--  2.0 unx     2437 b-     1166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Knox_IN
-rw-rw-r--  2.0 unx      208 b-       78 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Kralendijk
-rw-rw-r--  2.0 unx      243 b-       99 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/La_Paz
-rw-rw-r--  2.0 unx      417 b-      203 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Lima
-rw-rw-r--  2.0 unx     2845 b-     1342 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Los_Angeles
-rw-rw-r--  2.0 unx     2781 b-     1323 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Louisville
-rw-rw-r--  2.0 unx      208 b-       78 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Lower_Princes
-rw-rw-r--  2.0 unx      756 b-      367 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Maceio
-rw-rw-r--  2.0 unx      463 b-      222 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Managua
-rw-rw-r--  2.0 unx      616 b-      305 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Manaus
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Marigot
-rw-rw-r--  2.0 unx      257 b-      106 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Martinique
-rw-rw-r--  2.0 unx     1416 b-      686 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Matamoros
-rw-rw-r--  2.0 unx     1564 b-      747 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Mazatlan
-rw-rw-r--  2.0 unx     1173 b-      555 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Mendoza
-rw-rw-r--  2.0 unx     2283 b-     1091 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Menominee
-rw-rw-r--  2.0 unx     1456 b-      696 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Merida
-rw-rw-r--  2.0 unx      743 b-      379 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Metlakatla
-rw-rw-r--  2.0 unx     1618 b-      780 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Mexico_City
-rw-rw-r--  2.0 unx     1684 b-      796 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Miquelon
-rw-rw-r--  2.0 unx     3163 b-     1502 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Moncton
-rw-rw-r--  2.0 unx     1416 b-      685 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Monterrey
-rw-rw-r--  2.0 unx     2160 b-     1057 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Montevideo
-rw-rw-r--  2.0 unx     3503 b-     1668 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Montreal
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Montserrat
-rw-rw-r--  2.0 unx     2284 b-     1082 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Nassau
-rw-rw-r--  2.0 unx     3545 b-     1673 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/New_York
-rw-rw-r--  2.0 unx     2131 b-     1023 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Nipigon
-rw-rw-r--  2.0 unx     2376 b-     1158 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Nome
-rw-rw-r--  2.0 unx      728 b-      350 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Noronha
-rw-rw-r--  2.0 unx     2389 b-     1147 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/North_Dakota/Beulah
-rw-rw-r--  2.0 unx     2389 b-     1148 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/North_Dakota/Center
-rw-rw-r--  2.0 unx     2389 b-     1147 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/North_Dakota/New_Salem
-rw-rw-r--  2.0 unx     1522 b-      732 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Ojinaga
-rw-rw-r--  2.0 unx      203 b-       82 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Panama
-rw-rw-r--  2.0 unx     2108 b-      999 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Pangnirtung
-rw-rw-r--  2.0 unx      308 b-      121 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Paramaribo
-rw-rw-r--  2.0 unx      353 b-      168 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Phoenix
-rw-rw-r--  2.0 unx     1483 b-      721 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Port-au-Prince
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Port_of_Spain
-rw-rw-r--  2.0 unx      656 b-      316 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Porto_Acre
-rw-rw-r--  2.0 unx      588 b-      295 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Porto_Velho
-rw-rw-r--  2.0 unx      255 b-      108 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Puerto_Rico
-rw-rw-r--  2.0 unx     2131 b-     1031 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Rainy_River
-rw-rw-r--  2.0 unx     1930 b-      932 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Rankin_Inlet
-rw-rw-r--  2.0 unx      728 b-      357 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Recife
-rw-rw-r--  2.0 unx      994 b-      479 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Regina
-rw-rw-r--  2.0 unx     1930 b-      933 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Resolute
-rw-rw-r--  2.0 unx      656 b-      316 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Rio_Branco
-rw-rw-r--  2.0 unx     1129 b-      543 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Rosario
-rw-rw-r--  2.0 unx     2356 b-     1112 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Santa_Isabel
-rw-rw-r--  2.0 unx      626 b-      310 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Santarem
-rw-rw-r--  2.0 unx     2531 b-     1196 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Santiago
-rw-rw-r--  2.0 unx      489 b-      238 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Santo_Domingo
-rw-rw-r--  2.0 unx     2015 b-      976 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Sao_Paulo
-rw-rw-r--  2.0 unx     1925 b-      897 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Scoresbysund
-rw-rw-r--  2.0 unx     2453 b-     1166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Shiprock
-rw-rw-r--  2.0 unx     2350 b-     1146 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Sitka
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/St_Barthelemy
-rw-rw-r--  2.0 unx     3664 b-     1777 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/St_Johns
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/St_Kitts
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/St_Lucia
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/St_Thomas
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/St_Vincent
-rw-rw-r--  2.0 unx      574 b-      273 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Swift_Current
-rw-rw-r--  2.0 unx      278 b-      123 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Tegucigalpa
-rw-rw-r--  2.0 unx     1528 b-      726 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Thule
-rw-rw-r--  2.0 unx     2211 b-     1052 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Thunder_Bay
-rw-rw-r--  2.0 unx     2356 b-     1112 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Tijuana
-rw-rw-r--  2.0 unx     3503 b-     1657 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Toronto
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Tortola
-rw-rw-r--  2.0 unx     2901 b-     1370 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Vancouver
-rw-rw-r--  2.0 unx      170 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Virgin
-rw-rw-r--  2.0 unx     2093 b-      996 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Whitehorse
-rw-rw-r--  2.0 unx     2891 b-     1380 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Winnipeg
-rw-rw-r--  2.0 unx     2314 b-     1115 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Yakutat
-rw-rw-r--  2.0 unx     1980 b-      954 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/America/Yellowknife
-rw-rw-r--  2.0 unx      269 b-      106 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Casey
-rw-rw-r--  2.0 unx      290 b-      120 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Davis
-rw-rw-r--  2.0 unx      227 b-       83 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/DumontDUrville
-rw-rw-r--  2.0 unx     1518 b-      705 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Macquarie
-rw-rw-r--  2.0 unx      204 b-       69 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Mawson
-rw-rw-r--  2.0 unx     2460 b-     1144 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/McMurdo
-rw-rw-r--  2.0 unx     2054 b-      980 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Palmer
-rw-rw-r--  2.0 unx      173 b-       54 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Rothera
-rw-rw-r--  2.0 unx     2460 b-     1144 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/South_Pole
-rw-rw-r--  2.0 unx      174 b-       55 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Syowa
-rw-rw-r--  2.0 unx     1161 b-      556 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Troll
-rw-rw-r--  2.0 unx      174 b-       54 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Antarctica/Vostok
-rw-rw-r--  2.0 unx     2251 b-     1051 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Arctic/Longyearbyen
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Aden
-rw-rw-r--  2.0 unx      936 b-      464 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Almaty
-rw-rw-r--  2.0 unx     1877 b-      893 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Amman
-rw-rw-r--  2.0 unx     1197 b-      568 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Anadyr
-rw-rw-r--  2.0 unx     1142 b-      516 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Aqtau
-rw-rw-r--  2.0 unx     1052 b-      485 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Aqtobe
-rw-rw-r--  2.0 unx      671 b-      313 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Ashgabat
-rw-rw-r--  2.0 unx      671 b-      313 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Ashkhabad
-rw-rw-r--  2.0 unx      988 b-      484 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Baghdad
-rw-rw-r--  2.0 unx      209 b-       77 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Bahrain
-rw-rw-r--  2.0 unx     1956 b-      910 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Baku
-rw-rw-r--  2.0 unx      204 b-       79 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Bangkok
-rw-rw-r--  2.0 unx     2175 b-     1045 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Beirut
-rw-rw-r--  2.0 unx     1061 b-      506 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Bishkek
-rw-rw-r--  2.0 unx      201 b-       73 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Brunei
-rw-rw-r--  2.0 unx      291 b-      125 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Calcutta
-rw-rw-r--  2.0 unx      904 b-      422 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Choibalsan
-rw-rw-r--  2.0 unx      403 b-      186 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Chongqing
-rw-rw-r--  2.0 unx      403 b-      186 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Chungking
-rw-rw-r--  2.0 unx      389 b-      163 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Colombo
-rw-rw-r--  2.0 unx      390 b-      170 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Dacca
-rw-rw-r--  2.0 unx     2320 b-     1111 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Damascus
-rw-rw-r--  2.0 unx      390 b-      170 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Dhaka
-rw-rw-r--  2.0 unx      309 b-      119 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Dili
-rw-rw-r--  2.0 unx      171 b-       59 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Dubai
-rw-rw-r--  2.0 unx      611 b-      291 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Dushanbe
-rw-rw-r--  2.0 unx     2313 b-     1109 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Gaza
-rw-rw-r--  2.0 unx      477 b-      222 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Harbin
-rw-rw-r--  2.0 unx     2341 b-     1123 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Hebron
-rw-rw-r--  2.0 unx      269 b-      101 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Ho_Chi_Minh
-rw-rw-r--  2.0 unx     1189 b-      563 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Hong_Kong
-rw-rw-r--  2.0 unx      848 b-      400 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Hovd
-rw-rw-r--  2.0 unx     1229 b-      575 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Irkutsk
-rw-rw-r--  2.0 unx     2747 b-     1316 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Istanbul
-rw-rw-r--  2.0 unx      370 b-      165 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Jakarta
-rw-rw-r--  2.0 unx      239 b-       87 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Jayapura
-rw-rw-r--  2.0 unx     2265 b-     1090 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Jerusalem
-rw-rw-r--  2.0 unx      199 b-       81 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kabul
-rw-rw-r--  2.0 unx     1181 b-      563 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kamchatka
-rw-rw-r--  2.0 unx      403 b-      181 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Karachi
-rw-rw-r--  2.0 unx      433 b-      199 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kashgar
-rw-rw-r--  2.0 unx      212 b-       81 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kathmandu
-rw-rw-r--  2.0 unx      212 b-       81 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Katmandu
-rw-rw-r--  2.0 unx     1295 b-      603 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Khandyga
-rw-rw-r--  2.0 unx      291 b-      125 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kolkata
-rw-rw-r--  2.0 unx     1196 b-      563 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Krasnoyarsk
-rw-rw-r--  2.0 unx      398 b-      166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kuala_Lumpur
-rw-rw-r--  2.0 unx      519 b-      246 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kuching
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Kuwait
-rw-rw-r--  2.0 unx      795 b-      378 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Macao
-rw-rw-r--  2.0 unx      795 b-      378 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Macau
-rw-rw-r--  2.0 unx     1197 b-      561 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Magadan
-rw-rw-r--  2.0 unx      280 b-      107 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Makassar
-rw-rw-r--  2.0 unx      361 b-      181 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Manila
-rw-rw-r--  2.0 unx      171 b-       59 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Muscat
-rw-rw-r--  2.0 unx     2016 b-      961 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Nicosia
-rw-rw-r--  2.0 unx     1234 b-      580 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Novokuznetsk
-rw-rw-r--  2.0 unx     1210 b-      574 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Novosibirsk
-rw-rw-r--  2.0 unx     1196 b-      557 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Omsk
-rw-rw-r--  2.0 unx     1100 b-      502 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Oral
-rw-rw-r--  2.0 unx      269 b-      101 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Phnom_Penh
-rw-rw-r--  2.0 unx      375 b-      159 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Pontianak
-rw-rw-r--  2.0 unx      284 b-      119 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Pyongyang
-rw-rw-r--  2.0 unx      209 b-       77 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Qatar
-rw-rw-r--  2.0 unx     1082 b-      506 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Qyzylorda
-rw-rw-r--  2.0 unx      285 b-      117 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Rangoon
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Riyadh
-rw-rw-r--  2.0 unx      269 b-      101 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Saigon
-rw-rw-r--  2.0 unx     1227 b-      576 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Sakhalin
-rw-rw-r--  2.0 unx      691 b-      319 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Samarkand
-rw-rw-r--  2.0 unx      422 b-      193 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Seoul
-rw-rw-r--  2.0 unx      419 b-      201 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Shanghai
-rw-rw-r--  2.0 unx      428 b-      179 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Singapore
-rw-rw-r--  2.0 unx      750 b-      363 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Taipei
-rw-rw-r--  2.0 unx      681 b-      315 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Tashkent
-rw-rw-r--  2.0 unx     1142 b-      530 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Tbilisi
-rw-rw-r--  2.0 unx     1661 b-      775 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Tehran
-rw-rw-r--  2.0 unx     2265 b-     1090 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Tel_Aviv
-rw-rw-r--  2.0 unx      209 b-       76 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Thimbu
-rw-rw-r--  2.0 unx      209 b-       76 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Thimphu
-rw-rw-r--  2.0 unx      353 b-      192 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Tokyo
-rw-rw-r--  2.0 unx      280 b-      107 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Ujung_Pandang
-rw-rw-r--  2.0 unx      848 b-      398 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Ulaanbaatar
-rw-rw-r--  2.0 unx      848 b-      398 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Ulan_Bator
-rw-rw-r--  2.0 unx      403 b-      186 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Urumqi
-rw-rw-r--  2.0 unx     1263 b-      586 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Ust-Nera
-rw-rw-r--  2.0 unx      269 b-      102 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Vientiane
-rw-rw-r--  2.0 unx     1211 b-      560 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Vladivostok
-rw-rw-r--  2.0 unx     1197 b-      561 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Yakutsk
-rw-rw-r--  2.0 unx     1266 b-      572 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Yekaterinburg
-rw-rw-r--  2.0 unx     1277 b-      582 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Asia/Yerevan
-rw-rw-r--  2.0 unx     3488 b-     1641 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Azores
-rw-rw-r--  2.0 unx     2004 b-      962 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Bermuda
-rw-rw-r--  2.0 unx     1913 b-      892 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Canary
-rw-rw-r--  2.0 unx      254 b-      103 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Cape_Verde
-rw-rw-r--  2.0 unx     1829 b-      840 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Faeroe
-rw-rw-r--  2.0 unx     1829 b-      840 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Faroe
-rw-rw-r--  2.0 unx     2251 b-     1051 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Jan_Mayen
-rw-rw-r--  2.0 unx     3478 b-     1628 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Madeira
-rw-rw-r--  2.0 unx     1167 b-      553 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Reykjavik
-rw-rw-r--  2.0 unx      148 b-       68 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/South_Georgia
-rw-rw-r--  2.0 unx      203 b-       76 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/St_Helena
-rw-rw-r--  2.0 unx     1246 b-      597 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Atlantic/Stanley
-rw-rw-r--  2.0 unx     2209 b-     1047 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/ACT
-rw-rw-r--  2.0 unx     2224 b-     1079 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Adelaide
-rw-rw-r--  2.0 unx      439 b-      211 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Brisbane
-rw-rw-r--  2.0 unx     2259 b-     1110 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Broken_Hill
-rw-rw-r--  2.0 unx     2209 b-     1047 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Canberra
-rw-rw-r--  2.0 unx     2209 b-     1039 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Currie
-rw-rw-r--  2.0 unx      310 b-      173 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Darwin
-rw-rw-r--  2.0 unx      472 b-      231 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Eucla
-rw-rw-r--  2.0 unx     2321 b-     1083 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Hobart
-rw-rw-r--  2.0 unx     1847 b-      890 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/LHI
-rw-rw-r--  2.0 unx      509 b-      256 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Lindeman
-rw-rw-r--  2.0 unx     1847 b-      890 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Lord_Howe
-rw-rw-r--  2.0 unx     2209 b-     1045 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Melbourne
-rw-rw-r--  2.0 unx     2209 b-     1047 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/NSW
-rw-rw-r--  2.0 unx      310 b-      173 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/North
-rw-rw-r--  2.0 unx      466 b-      229 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Perth
-rw-rw-r--  2.0 unx      439 b-      211 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Queensland
-rw-rw-r--  2.0 unx     2224 b-     1079 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/South
-rw-rw-r--  2.0 unx     2209 b-     1047 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Sydney
-rw-rw-r--  2.0 unx     2321 b-     1083 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Tasmania
-rw-rw-r--  2.0 unx     2209 b-     1045 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Victoria
-rw-rw-r--  2.0 unx      466 b-      229 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/West
-rw-rw-r--  2.0 unx     2259 b-     1110 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Australia/Yancowinna
-rw-rw-r--  2.0 unx      656 b-      316 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Brazil/Acre
-rw-rw-r--  2.0 unx      728 b-      350 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Brazil/DeNoronha
-rw-rw-r--  2.0 unx     2015 b-      976 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Brazil/East
-rw-rw-r--  2.0 unx      616 b-      305 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Brazil/West
-rw-rw-r--  2.0 unx     2102 b-      976 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/CET
-rw-rw-r--  2.0 unx     2294 b-     1097 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/CST6CDT
-rw-rw-r--  2.0 unx     3438 b-     1631 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Atlantic
-rw-rw-r--  2.0 unx     2891 b-     1380 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Central
-rw-rw-r--  2.0 unx      994 b-      479 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/East-Saskatchewan
-rw-rw-r--  2.0 unx     3503 b-     1657 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Eastern
-rw-rw-r--  2.0 unx     2402 b-     1145 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Mountain
-rw-rw-r--  2.0 unx     3664 b-     1777 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Newfoundland
-rw-rw-r--  2.0 unx     2901 b-     1370 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Pacific
-rw-rw-r--  2.0 unx      994 b-      479 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Saskatchewan
-rw-rw-r--  2.0 unx     2093 b-      996 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Canada/Yukon
-rw-rw-r--  2.0 unx     2531 b-     1196 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Chile/Continental
-rw-rw-r--  2.0 unx     2295 b-     1086 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Chile/EasterIsland
-rw-rw-r--  2.0 unx     2437 b-     1157 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Cuba
-rw-rw-r--  2.0 unx     1876 b-      881 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/EET
-rw-rw-r--  2.0 unx      127 b-       42 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/EST
-rw-rw-r--  2.0 unx     2294 b-     1088 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/EST5EDT
-rw-rw-r--  2.0 unx     2795 b-     1357 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Egypt
-rw-rw-r--  2.0 unx     3559 b-     1684 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Eire
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+0
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+1
-rw-rw-r--  2.0 unx      139 b-       48 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+10
-rw-rw-r--  2.0 unx      139 b-       48 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+11
-rw-rw-r--  2.0 unx      139 b-       47 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+12
-rw-rw-r--  2.0 unx      135 b-       45 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+2
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+3
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+4
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+5
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+6
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+7
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+8
-rw-rw-r--  2.0 unx      135 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT+9
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-0
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-1
-rw-rw-r--  2.0 unx      140 b-       47 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-10
-rw-rw-r--  2.0 unx      140 b-       47 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-11
-rw-rw-r--  2.0 unx      140 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-12
-rw-rw-r--  2.0 unx      140 b-       47 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-13
-rw-rw-r--  2.0 unx      140 b-       47 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-14
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-2
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-3
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-4
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-5
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-6
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-7
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-8
-rw-rw-r--  2.0 unx      136 b-       46 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT-9
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/GMT0
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/Greenwich
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/UCT
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/UTC
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/Universal
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Etc/Zulu
-rw-rw-r--  2.0 unx     2943 b-     1355 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Amsterdam
-rw-rw-r--  2.0 unx     1751 b-      813 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Andorra
-rw-rw-r--  2.0 unx     2271 b-     1065 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Athens
-rw-rw-r--  2.0 unx     3687 b-     1743 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Belfast
-rw-rw-r--  2.0 unx     1957 b-      906 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Belgrade
-rw-rw-r--  2.0 unx     2335 b-     1088 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Berlin
-rw-rw-r--  2.0 unx     2272 b-     1083 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Bratislava
-rw-rw-r--  2.0 unx     2970 b-     1434 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Brussels
-rw-rw-r--  2.0 unx     2221 b-     1067 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Bucharest
-rw-rw-r--  2.0 unx     2433 b-     1144 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Budapest
-rw-rw-r--  2.0 unx     1918 b-      941 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Busingen
-rw-rw-r--  2.0 unx     2433 b-     1144 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Chisinau
-rw-rw-r--  2.0 unx     2160 b-     1051 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Copenhagen
-rw-rw-r--  2.0 unx     3559 b-     1684 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Dublin
-rw-rw-r--  2.0 unx     3061 b-     1438 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Gibraltar
-rw-rw-r--  2.0 unx     3687 b-     1743 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Guernsey
-rw-rw-r--  2.0 unx     1909 b-      892 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Helsinki
-rw-rw-r--  2.0 unx     3687 b-     1743 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Isle_of_Man
-rw-rw-r--  2.0 unx     2747 b-     1316 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Istanbul
-rw-rw-r--  2.0 unx     3687 b-     1743 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Jersey
-rw-rw-r--  2.0 unx     1520 b-      700 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Kaliningrad
-rw-rw-r--  2.0 unx     2097 b-      990 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Kiev
-rw-rw-r--  2.0 unx     3453 b-     1624 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Lisbon
-rw-rw-r--  2.0 unx     1957 b-      906 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Ljubljana
-rw-rw-r--  2.0 unx     3687 b-     1743 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/London
-rw-rw-r--  2.0 unx     2974 b-     1377 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Luxembourg
-rw-rw-r--  2.0 unx     2619 b-     1228 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Madrid
-rw-rw-r--  2.0 unx     2629 b-     1236 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Malta
-rw-rw-r--  2.0 unx     1909 b-      892 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Mariehamn
-rw-rw-r--  2.0 unx     1354 b-      632 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Minsk
-rw-rw-r--  2.0 unx     2953 b-     1366 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Monaco
-rw-rw-r--  2.0 unx     1490 b-      705 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Moscow
-rw-rw-r--  2.0 unx     2016 b-      961 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Nicosia
-rw-rw-r--  2.0 unx     2251 b-     1051 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Oslo
-rw-rw-r--  2.0 unx     2971 b-     1367 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Paris
-rw-rw-r--  2.0 unx     1957 b-      906 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Podgorica
-rw-rw-r--  2.0 unx     2272 b-     1083 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Prague
-rw-rw-r--  2.0 unx     2235 b-     1059 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Riga
-rw-rw-r--  2.0 unx     2678 b-     1310 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Rome
-rw-rw-r--  2.0 unx     1344 b-      599 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Samara
-rw-rw-r--  2.0 unx     2678 b-     1310 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/San_Marino
-rw-rw-r--  2.0 unx     1957 b-      906 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Sarajevo
-rw-rw-r--  2.0 unx     1474 b-      703 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Simferopol
-rw-rw-r--  2.0 unx     1957 b-      906 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Skopje
-rw-rw-r--  2.0 unx     2130 b-     1072 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Sofia
-rw-rw-r--  2.0 unx     1918 b-      936 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Stockholm
-rw-rw-r--  2.0 unx     2201 b-     1040 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Tallinn
-rw-rw-r--  2.0 unx     2098 b-      991 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Tirane
-rw-rw-r--  2.0 unx     2433 b-     1144 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Tiraspol
-rw-rw-r--  2.0 unx     2103 b-      992 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Uzhgorod
-rw-rw-r--  2.0 unx     1918 b-      941 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Vaduz
-rw-rw-r--  2.0 unx     2678 b-     1310 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Vatican
-rw-rw-r--  2.0 unx     2237 b-     1046 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Vienna
-rw-rw-r--  2.0 unx     2199 b-     1027 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Vilnius
-rw-rw-r--  2.0 unx     1248 b-      580 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Volgograd
-rw-rw-r--  2.0 unx     2705 b-     1270 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Warsaw
-rw-rw-r--  2.0 unx     1957 b-      906 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Zagreb
-rw-rw-r--  2.0 unx     2111 b-     1000 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Zaporozhye
-rw-rw-r--  2.0 unx     1918 b-      941 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Europe/Zurich
-rw-rw-r--  2.0 unx      264 b-       83 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Factory
-rw-rw-r--  2.0 unx     3687 b-     1743 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/GB
-rw-rw-r--  2.0 unx     3687 b-     1743 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/GB-Eire
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/GMT
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/GMT+0
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/GMT-0
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/GMT0
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Greenwich
-rw-rw-r--  2.0 unx      128 b-       42 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/HST
-rw-rw-r--  2.0 unx     1189 b-      563 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Hongkong
-rw-rw-r--  2.0 unx     1167 b-      553 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Iceland
-rw-rw-r--  2.0 unx      241 b-       89 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Antananarivo
-rw-rw-r--  2.0 unx      201 b-       74 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Chagos
-rw-rw-r--  2.0 unx      149 b-       66 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Christmas
-rw-rw-r--  2.0 unx      152 b-       69 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Cocos
-rw-rw-r--  2.0 unx      171 b-       59 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Comoro
-rw-rw-r--  2.0 unx      171 b-       54 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Kerguelen
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Mahe
-rw-rw-r--  2.0 unx      204 b-       79 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Maldives
-rw-rw-r--  2.0 unx      253 b-      104 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Mauritius
-rw-rw-r--  2.0 unx      171 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Mayotte
-rw-rw-r--  2.0 unx      171 b-       57 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Indian/Reunion
-rw-rw-r--  2.0 unx     1661 b-      775 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Iran
-rw-rw-r--  2.0 unx     2265 b-     1090 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Israel
-rw-rw-r--  2.0 unx      507 b-      255 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Jamaica
-rw-rw-r--  2.0 unx      353 b-      192 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Japan
-rw-rw-r--  2.0 unx      237 b-      100 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Kwajalein
-rw-rw-r--  2.0 unx      655 b-      331 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Libya
-rw-rw-r--  2.0 unx     2102 b-      976 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/MET
-rw-rw-r--  2.0 unx      127 b-       42 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/MST
-rw-rw-r--  2.0 unx     2294 b-     1095 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/MST7MDT
-rw-rw-r--  2.0 unx     2356 b-     1112 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Mexico/BajaNorte
-rw-rw-r--  2.0 unx     1564 b-      747 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Mexico/BajaSur
-rw-rw-r--  2.0 unx     1618 b-      780 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Mexico/General
-rw-rw-r--  2.0 unx     2460 b-     1144 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/NZ
-rw-rw-r--  2.0 unx     2032 b-      951 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/NZ-CHAT
-rw-rw-r--  2.0 unx     2453 b-     1166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Navajo
-rw-rw-r--  2.0 unx      419 b-      201 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/PRC
-rw-rw-r--  2.0 unx     2294 b-     1091 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/PST8PDT
-rw-rw-r--  2.0 unx     1101 b-      536 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Apia
-rw-rw-r--  2.0 unx     2460 b-     1144 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Auckland
-rw-rw-r--  2.0 unx     2032 b-      951 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Chatham
-rw-rw-r--  2.0 unx      153 b-       68 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Chuuk
-rw-rw-r--  2.0 unx     2295 b-     1086 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Easter
-rw-rw-r--  2.0 unx      478 b-      236 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Efate
-rw-rw-r--  2.0 unx      230 b-       97 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Enderbury
-rw-rw-r--  2.0 unx      197 b-       82 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Fakaofo
-rw-rw-r--  2.0 unx     1078 b-      540 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Fiji
-rw-rw-r--  2.0 unx      150 b-       67 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Funafuti
-rw-rw-r--  2.0 unx      211 b-       81 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Galapagos
-rw-rw-r--  2.0 unx      173 b-       58 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Gambier
-rw-rw-r--  2.0 unx      172 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Guadalcanal
-rw-rw-r--  2.0 unx      225 b-       99 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Guam
-rw-rw-r--  2.0 unx      276 b-      124 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Honolulu
-rw-rw-r--  2.0 unx      276 b-      124 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Johnston
-rw-rw-r--  2.0 unx      230 b-       94 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Kiritimati
-rw-rw-r--  2.0 unx      230 b-       90 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Kosrae
-rw-rw-r--  2.0 unx      237 b-      100 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Kwajalein
-rw-rw-r--  2.0 unx      197 b-       79 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Majuro
-rw-rw-r--  2.0 unx      176 b-       64 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Marquesas
-rw-rw-r--  2.0 unx      294 b-      119 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Midway
-rw-rw-r--  2.0 unx      254 b-      104 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Nauru
-rw-rw-r--  2.0 unx      226 b-       93 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Niue
-rw-rw-r--  2.0 unx      208 b-       84 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Norfolk
-rw-rw-r--  2.0 unx      314 b-      129 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Noumea
-rw-rw-r--  2.0 unx      312 b-      128 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Pago_Pago
-rw-rw-r--  2.0 unx      149 b-       66 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Palau
-rw-rw-r--  2.0 unx      203 b-       82 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Pitcairn
-rw-rw-r--  2.0 unx      153 b-       67 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Pohnpei
-rw-rw-r--  2.0 unx      153 b-       67 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Ponape
-rw-rw-r--  2.0 unx      172 b-       82 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Port_Moresby
-rw-rw-r--  2.0 unx      574 b-      294 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Rarotonga
-rw-rw-r--  2.0 unx      255 b-      112 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Saipan
-rw-rw-r--  2.0 unx      312 b-      128 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Samoa
-rw-rw-r--  2.0 unx      174 b-       60 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Tahiti
-rw-rw-r--  2.0 unx      153 b-       68 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Tarawa
-rw-rw-r--  2.0 unx      339 b-      148 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Tongatapu
-rw-rw-r--  2.0 unx      153 b-       68 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Truk
-rw-rw-r--  2.0 unx      153 b-       68 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Wake
-rw-rw-r--  2.0 unx      150 b-       67 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Wallis
-rw-rw-r--  2.0 unx      153 b-       68 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Pacific/Yap
-rw-rw-r--  2.0 unx     2705 b-     1270 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Poland
-rw-rw-r--  2.0 unx     3453 b-     1624 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Portugal
-rw-rw-r--  2.0 unx      750 b-      363 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/ROC
-rw-rw-r--  2.0 unx      422 b-      193 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/ROK
-rw-rw-r--  2.0 unx      428 b-      179 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Singapore
-rw-rw-r--  2.0 unx     2747 b-     1316 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Turkey
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/UCT
-rw-rw-r--  2.0 unx     2384 b-     1150 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Alaska
-rw-rw-r--  2.0 unx     2379 b-     1151 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Aleutian
-rw-rw-r--  2.0 unx      353 b-      168 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Arizona
-rw-rw-r--  2.0 unx     3585 b-     1703 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Central
-rw-rw-r--  2.0 unx     1675 b-      807 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/East-Indiana
-rw-rw-r--  2.0 unx     3545 b-     1673 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Eastern
-rw-rw-r--  2.0 unx      276 b-      124 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Hawaii
-rw-rw-r--  2.0 unx     2437 b-     1166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Indiana-Starke
-rw-rw-r--  2.0 unx     2216 b-     1051 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Michigan
-rw-rw-r--  2.0 unx     2453 b-     1166 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Mountain
-rw-rw-r--  2.0 unx     2845 b-     1342 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Pacific
-rw-rw-r--  2.0 unx     2845 b-     1342 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Pacific-New
-rw-rw-r--  2.0 unx      312 b-      128 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/US/Samoa
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/UTC
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Universal
-rw-rw-r--  2.0 unx     1490 b-      705 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/W-SU
-rw-rw-r--  2.0 unx     1873 b-      876 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/WET
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/Zulu
-rw-rw-r--  2.0 unx     4419 b-     2590 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/iso3166.tab
-rw-rw-r--  2.0 unx      127 b-       37 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/localtime
-rw-rw-r--  2.0 unx     3545 b-     1673 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/posixrules
-rw-rw-r--  2.0 unx    20542 b-     9618 defN 14-May-20 11:05 .deps/pytz-2014.3-py2.7.egg/pytz/zoneinfo/zone.tab
-rw-rw-r--  2.0 unx      771 b-      423 defN 14-May-20 11:05 .deps/six-1.6.1-py2.py3-none-any.whl/six-1.6.1.dist-info/DESCRIPTION.rst
-rw-rw-r--  2.0 unx     1279 b-      645 defN 14-May-20 11:05 .deps/six-1.6.1-py2.py3-none-any.whl/six-1.6.1.dist-info/METADATA
-rw-rw-r--  2.0 unx      531 b-      351 defN 14-May-20 11:05 .deps/six-1.6.1-py2.py3-none-any.whl/six-1.6.1.dist-info/RECORD
-rw-rw-r--  2.0 unx      110 b-       95 defN 14-May-20 11:05 .deps/six-1.6.1-py2.py3-none-any.whl/six-1.6.1.dist-info/WHEEL
-rw-rw-r--  2.0 unx      621 b-      365 defN 14-May-20 11:05 .deps/six-1.6.1-py2.py3-none-any.whl/six-1.6.1.dist-info/pydist.json
-rw-rw-r--  2.0 unx        4 b-        6 defN 14-May-20 11:05 .deps/six-1.6.1-py2.py3-none-any.whl/six-1.6.1.dist-info/top_level.txt
-rw-rw-r--  2.0 unx    23462 b-     5750 defN 14-May-20 11:05 .deps/six-1.6.1-py2.py3-none-any.whl/six.py
-rw-rw-r--  2.0 unx       10 b-       12 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python-0.2.1.dist-info/DESCRIPTION.rst
-rw-rw-r--  2.0 unx      785 b-      437 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python-0.2.1.dist-info/METADATA
-rw-rw-r--  2.0 unx     5677 b-     2352 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python-0.2.1.dist-info/RECORD
-rw-rw-r--  2.0 unx       92 b-       92 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python-0.2.1.dist-info/WHEEL
-rw-rw-r--  2.0 unx      897 b-      510 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python-0.2.1.dist-info/metadata.json
-rw-rw-r--  2.0 unx       15 b-       17 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python-0.2.1.dist-info/top_level.txt
-rw-rw-r--  2.0 unx     2591 b-     1043 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/__init__.py
-rw-rw-r--  2.0 unx      917 b-      337 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/datatypes.py
-rw-rw-r--  2.0 unx     2013 b-      659 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/errors.py
-rw-rw-r--  2.0 unx        0 b-        2 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/__init__.py
-rw-rw-r--  2.0 unx     3689 b-     1300 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/column.py
-rw-rw-r--  2.0 unx     8062 b-     2114 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/connection.py
-rw-rw-r--  2.0 unx     6372 b-     1617 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/cursor.py
-rw-rw-r--  2.0 unx     2354 b-      587 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/__init__.py
-rw-rw-r--  2.0 unx        0 b-        2 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/__init__.py
-rw-rw-r--  2.0 unx      715 b-      360 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/authentication.py
-rw-rw-r--  2.0 unx      339 b-      184 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/backend_key_data.py
-rw-rw-r--  2.0 unx      185 b-      123 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/bind_complete.py
-rw-rw-r--  2.0 unx      187 b-      122 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/close_complete.py
-rw-rw-r--  2.0 unx      875 b-      357 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/command_complete.py
-rw-rw-r--  2.0 unx      378 b-      222 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/copy_in_response.py
-rw-rw-r--  2.0 unx      691 b-      326 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/data_row.py
-rw-rw-r--  2.0 unx      197 b-      131 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/empty_query_response.py
-rw-rw-r--  2.0 unx      299 b-      149 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/error_response.py
-rw-rw-r--  2.0 unx      173 b-      118 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/no_data.py
-rw-rw-r--  2.0 unx     2201 b-      765 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/notice_response.py
-rw-rw-r--  2.0 unx      531 b-      271 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/parameter_description.py
-rw-rw-r--  2.0 unx      461 b-      249 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/parameter_status.py
-rw-rw-r--  2.0 unx      187 b-      124 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/parse_complete.py
-rw-rw-r--  2.0 unx      191 b-      126 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/portal_suspended.py
-rw-rw-r--  2.0 unx      426 b-      238 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/ready_for_query.py
-rw-rw-r--  2.0 unx      922 b-      399 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/row_description.py
-rw-rw-r--  2.0 unx      244 b-      144 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/backend_messages/unknown.py
-rw-rw-r--  2.0 unx        0 b-        2 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/__init__.py
-rw-rw-r--  2.0 unx      912 b-      350 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/bind.py
-rw-rw-r--  2.0 unx      454 b-      233 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/cancel_request.py
-rw-rw-r--  2.0 unx      708 b-      319 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/close.py
-rw-rw-r--  2.0 unx      438 b-      239 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/copy_data.py
-rw-rw-r--  2.0 unx      179 b-      120 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/copy_done.py
-rw-rw-r--  2.0 unx      405 b-      211 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/copy_fail.py
-rw-rw-r--  2.0 unx      753 b-      322 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/describe.py
-rw-rw-r--  2.0 unx      453 b-      231 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/execute.py
-rw-rw-r--  2.0 unx      173 b-      118 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/flush.py
-rw-rw-r--  2.0 unx      630 b-      287 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/parse.py
-rw-rw-r--  2.0 unx     1434 b-      494 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/password.py
-rw-rw-r--  2.0 unx      426 b-      226 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/query.py
-rw-rw-r--  2.0 unx      282 b-      178 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/ssl_request.py
-rw-rw-r--  2.0 unx      942 b-      353 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/startup.py
-rw-rw-r--  2.0 unx      171 b-      117 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/sync.py
-rw-rw-r--  2.0 unx      181 b-      122 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/frontend_messages/terminate.py
-rw-rw-r--  2.0 unx     1395 b-      495 defN 14-May-20 11:05 .deps/vertica_python-0.2.1-py2-none-any.whl/vertica_python/vertica/messages/message.py
-rw-rw-r--  2.0 unx      735 b-      435 defN 14-May-20 11:05 PEX-INFO
-rw-rw-r--  2.0 unx      754 b-      336 defN 14-May-20 11:05 __main__.py
710 files, 1567542 bytes uncompressed, 720497 bytes compressed:  54.0%
```

The .pex works

```
~/workspace/vertica-python git vertica-python/. master    
% ./vertica-python.pex          
Python 2.7.6 (default, Mar 22 2014, 22:59:56) 
[GCC 4.8.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
(InteractiveConsole)
>>> import vertica_python
>>> dir(vertica_python)
['BINARY', 'Binary', 'Connection', 'ConnectionError', 'DATETIME', 'DataError', 'DatabaseError', 'Date', 'DateFromTicks', 'Decimal', 'EmptyQueryError', 'Error', 'IntegrityError', 'InterfaceError', 'InternalError', 'MessageError', 'NUMBER', 'NotSupportedError', 'OperationalError', 'PROTOCOL_VERSION', 'ProgrammingError', 'QueryError', 'ROWID', 'SSLNotSupported', 'STRING', 'Time', 'TimeFromTicks', 'TimedOutError', 'Timestamp', 'TimestampFromTicks', 'Warning', '__author__', '__builtins__', '__copyright__', '__doc__', '__file__', '__license__', '__name__', '__package__', '__path__', '__version__', 'absolute_import', 'apilevel', 'connect', 'datatypes', 'date', 'datetime', 'errors', 'paramstyle', 're', 'threadsafety', 'time', 'version_info', 'vertica']
>>> vertica_python.__file__
'/home/ksweeney/.pex/install/vertica_python-0.2.1-py2-none-any.whl.9bc2722ca831560607573d594c16363bbd7642ed/vertica_python-0.2.1-py2-none-any.whl/vertica_python/__init__.py'
>>> 
```
