### PR TITLE
Explicitly Define Vertica Error Classes

### DIFF
--- a/vertica_python/errors.py
+++ b/vertica_python/errors.py
@@ -74,29 +74,38 @@ class QueryError(ProgrammingError):
             klass = cls
         return klass(error_response, sql)
 
+
 class LockFailure(QueryError):
     pass
+
 
 class InsufficientResources(QueryError):
     pass
 
+
 class OutOfMemory(QueryError):
     pass
+
 
 class VerticaSyntaxError(QueryError):
     pass
 
+
 class MissingRelation(QueryError):
     pass
+
 
 class MissingColumn(QueryError):
     pass
 
+
 class CopyRejected(QueryError):
     pass
 
+
 class PermissionDenied(QueryError):
     pass
+
     
 class InvalidDatetimeFormat(QueryError):
     pass


### PR DESCRIPTION
Right now, it's hard to do error handling for specific errors, such as SyntaxError and InsufficientResources. This change adds the ability to easily catch those error classes. 

Example: 

``` python
try:
    query_syntax_error = 'select count(*) frm my_table'
    data = get_data(query_syntax_error)
except VerticaSyntaxError:
    print('VerticaSyntaxError caught.')
```
