### PR TITLE
update column descriptions on cursor.nextset()

### DIFF
--- a/vertica_python/tests/test_cursor.py
+++ b/vertica_python/tests/test_cursor.py
@@ -348,6 +348,27 @@ class CursorTestCase(VerticaPythonTestCase):
             with self.assertRaises(errors.MissingColumn):
                 cur.nextset()
 
+    def test_nextset_with_different_columns(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+
+            cur.execute("SELECT 1 AS foo; SELECT 1 AS bar, 2 AS baz")
+
+            # verify data from first query
+            res1 = cur.fetchall()
+            self.assertListOfListsEqual(res1, [[1]])
+            self.assertEqual([col.name for col in cur.description], ['foo'])
+            self.assertIsNone(cur.fetchone())
+            self.assertTrue(cur.nextset())
+
+            # verify data from second query
+            res2 = cur.fetchall()
+            self.assertListOfListsEqual(res2, [[1, 2]])
+            self.assertEqual([col.name for col in cur.description], ['bar', 'baz'])
+            self.assertIsNone(cur.fetchone())
+            self.assertFalse(cur.nextset())
+
+
     # unit test for #144
     def test_empty_query(self):
         with self._connect() as conn:

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -209,6 +209,7 @@ class Cursor(object):
             self._message = self.connection.read_message()
             if isinstance(self._message, messages.RowDescription):
                 # next row will be either a DataRow or CommandComplete
+                self.description = [Column(fd, self.unicode_error) for fd in self._message.fields]
                 self._message = self.connection.read_message()
                 return True
             elif isinstance(self._message, messages.ReadyForQuery):


### PR DESCRIPTION
This patch allows the user to `nextset()` with queries that have different row descriptions. See the unit test for an example that was failing prior to this change.