### PR TITLE
Handle unicode column names

### DIFF
--- a/vertica_python/tests/integration_tests/test_column.py
+++ b/vertica_python/tests/integration_tests/test_column.py
@@ -40,14 +40,14 @@ from .base import VerticaPythonIntegrationTestCase
 
 class ColumnTestCase(VerticaPythonIntegrationTestCase):
     def test_column_names_query(self):
-        columns = ['isocode', 'name']
+        columns = ['isocode', 'name', u'\uFF04']
 
         with self._connect() as conn:
             cur = conn.cursor()
-            cur.execute("""
-                SELECT 'US' AS {0}, 'United States' AS {1}
-                UNION ALL SELECT 'CA', 'Canada'
-                UNION ALL SELECT 'MX', 'Mexico' """.format(*columns))
+            cur.execute(u"""
+                SELECT 'US' AS {0}, 'United States' AS {1}, 'USD' AS {2}
+                UNION ALL SELECT 'CA', 'Canada', 'CAD'
+                UNION ALL SELECT 'MX', 'Mexico', 'MXN' """.format(*columns))
             description = cur.description
 
         self.assertListEqual([d.name for d in description], columns)

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -141,7 +141,7 @@ ColumnTuple = namedtuple('Column', ['name', 'type_code', 'display_size', 'intern
 
 class Column(object):
     def __init__(self, col, unicode_error=None):
-        self.name = col['name'].decode()
+        self.name = col['name'].decode(UTF_8)
         self.type_code = col['data_type_oid']
         self.display_size = None
         self.internal_size = col['data_type_size']


### PR DESCRIPTION
Add to a unit test to ensure that we can handle UTF-8 column names, as
well as a patch so that 2.7 can make use of them (it already works correctly
with 3).