### PR TITLE
fixes #181

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -150,7 +150,7 @@ class Cursor(object):
 
             copy_statement = (
                 u"COPY {0} ({1}) FROM STDIN DELIMITER ',' ENCLOSED BY '\"' "
-                u"ENFORCELENGTH ABORT ON ERROR").format(target, variables)
+                u"ENFORCELENGTH ABORT ON ERROR NULL 'NULL'").format(target, variables)
 
             self.copy(copy_statement, data)
 
@@ -262,7 +262,7 @@ class Cursor(object):
 
     def copy(self, sql, data, **kwargs):
         """
-        
+
         EXAMPLE:
         >> with open("/tmp/file.csv", "rb") as fs:
         >>     cursor.copy("COPY table(field1,field2) FROM STDIN DELIMITER ',' ENCLOSED BY ''''",


### PR DESCRIPTION
I did further research and found that the method `format_operation_with_parameters()` in `cursor.py` converts parameters from `None` to `"NULL"` by default which results in an error when issuing a `COPY` statement because the `NULL` option in the `COPY` statement `NULL` is just an option for `COPY` according to [Vertica's Documentation](https://my.vertica.com/docs/7.1.x/HTML/Content/Authoring/SQLReferenceManual/Statements/COPY/COPY.htm). Since the default behavior for python is to convert `None` to 'NULL'  for RDBMS and in `cursor.py` the default behavior is to convert `None` to 'NULL', then I just set the NULL option as a default to be `NULL`. 