### PR TITLE
 FIX: format_quote fails for unicode in py2 

### DIFF
--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -342,10 +342,10 @@ class CursorTestCase(VerticaPythonIntegrationTestCase):
             cur = conn.cursor()
 
             # insert data
-
             cur.execute("INSERT INTO {0} (a, b) VALUES (1, 'aa')".format(self._table))
             cur.execute("INSERT INTO {0} (a, b) VALUES (2, 'bb')".format(self._table))
             conn.commit()
+
             cur.execute("""
                           SELECT * FROM {0} ORDER BY a ASC;
                           DELETE FROM {0};

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -410,6 +410,6 @@ class Cursor(object):
     def format_quote(self, param, is_csv):
         # TODO Make sure adapt() behaves properly
         if is_csv:
-            return u'"{0}"'.format(re.escape(param)).encode(UTF_8)
+            return u'"{0}"'.format(re.escape(param))
         else:
             return QuotedString(param.encode(UTF_8, self.unicode_error)).getquoted()

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -410,6 +410,6 @@ class Cursor(object):
     def format_quote(self, param, is_csv):
         # TODO Make sure adapt() behaves properly
         if is_csv:
-            return '"{0}"'.format(re.escape(param))
+            return u'"{0}"'.format(re.escape(param)).encode(UTF_8)
         else:
             return QuotedString(param.encode(UTF_8, self.unicode_error)).getquoted()


### PR DESCRIPTION
We're (vertica-python) converting all input to this method to unicode, but then letting py2 convert to ascii when calling format. This is causing issues when using executemany with params including unicode chars (e.g., `'Frühstück'`)

In an earlier version of this PR, I was using .encode(), but I don't think we need it since we end up casting to unicode/py3 str anyway.