### PR TITLE
Optimize Logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup(
         'python-dateutil>=1.5',
         'pytz',
         'future',
-        'six>=1.10.0'
+        'six>=1.10.0',
+        'numpydoc'
     ],
     extras_require={'namedparams': ['psycopg2>=2.5.1']},
     classifiers=[

--- a/vertica_python/vertica/log.py
+++ b/vertica_python/vertica/log.py
@@ -66,6 +66,6 @@ class VerticaLogging(object):
         if directory != '' and not os.path.exists(directory):
             try:
                 os.makedirs(directory)
-            except OSError as e:
-                if e.errno != errno.EEXIST:
+            except OSError as error:
+                if error.errno != errno.EEXIST:
                     raise


### PR DESCRIPTION
Changed all Logging functions from "'{}'.format(argument)" syntax to "'%s',argument" syntax to allow for lazy loading only in cases where the logging is actually enabled.