### PR TITLE
Add lost connectivity error

### DIFF
--- a/vertica_python/errors.py
+++ b/vertica_python/errors.py
@@ -182,6 +182,10 @@ class ConnectionFailure(QueryError):
     pass
 
 
+class LostConnectivityFailure(QueryError):
+    pass
+
+
 QUERY_ERROR_CLASSES = {
     b'55V03': LockFailure,
     b'53000': InsufficientResources,
@@ -195,5 +199,6 @@ QUERY_ERROR_CLASSES = {
     b'22007': InvalidDatetimeFormat,
     b'42710': DuplicateObject,
     b'57014': QueryCanceled,
-    b'08006': ConnectionFailure
+    b'08006': ConnectionFailure,
+    b'V1001': LostConnectivityFailure
 }


### PR DESCRIPTION
This PR adds a mapping of the ERRCODE_LOST_CONNECTIVITY as it is documented here:
https://www.vertica.com/docs/9.2.x/HTML/Content/Authoring/ErrorCodes/SqlState-V1001.htm

I considered just mapping this error code to the previous one that was mapped (08006 - ConnectionFailure) or just using the generic ConnectionError class. However based on the documentation is seems Vertica treats this condition as a very unique case and I preferred to add an additional class for it.