### PR TITLE
Add psycopg2 dependency and fixes QuotedString import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     packages=find_packages(),
     license="Apache License 2.0",
     install_requires=[
+        'psycopg2',
         'python-dateutil>=1.5',
         'pytz',
         'future',

--- a/setup.py
+++ b/setup.py
@@ -54,11 +54,11 @@ setup(
     packages=find_packages(),
     license="Apache License 2.0",
     install_requires=[
-        'psycopg2',
         'python-dateutil>=1.5',
         'pytz',
         'future',
-        'six>=1.10.0'
+        'six>=1.10.0',
+        'psycopg2'
     ],
     extras_require={'namedparams': ['psycopg2>=2.5.1']},
     classifiers=[

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -54,6 +54,10 @@ from six import binary_type, text_type, string_types, BytesIO, StringIO
 try:
     from psycopg2.extensions import QuotedString
 except ImportError:
+    pass
+try:
+   from psycopg2._psycopg import QuotedString
+except ImportError:
     class QuotedString(object):
         def __init__(self, s):
             raise ImportError("couldn't import psycopg2.extensions.QuotedString")

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -54,13 +54,12 @@ from six import binary_type, text_type, string_types, BytesIO, StringIO
 try:
     from psycopg2.extensions import QuotedString
 except ImportError:
-    pass
-try:
-   from psycopg2._psycopg import QuotedString
-except ImportError:
-    class QuotedString(object):
-        def __init__(self, s):
-            raise ImportError("couldn't import psycopg2.extensions.QuotedString")
+    try:
+        from psycopg2._psycopg import QuotedString
+    except ImportError:
+        class QuotedString(object):
+            def __init__(self, s):
+                raise ImportError("couldn't import psycopg2.extensions.QuotedString")
 
 from .. import errors
 from ..compat import as_text


### PR DESCRIPTION
When using psycopg2==2.7.6.1, cursor.py had the following error

    raise ImportError("couldn't import psycopg2.extensions.QuotedString")
ImportError: couldn't import psycopg2.extensions.QuotedString

This patch allows to import QuotedString with this version