### PR TITLE
Fix #251: Write notice messages to log

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -467,8 +467,7 @@ class Connection(object):
             if getattr(self, 'notice_handler', None) is not None:
                 self.notice_handler(message)
             else:
-                print('{}: {}'.format(message.values['Severity'],
-                                      message.values['Message']))
+                self._logger.warning(message.error_message())
 
     def read_message(self):
         while True:


### PR DESCRIPTION
Print notice messages is not a good idea, write to log as a quick fix. Further design will be tracked in #243.