### PR TITLE
Remove psycopg2 dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ To install vertica-python with pip:
 
     pip install vertica-python
 
-To install vertica-python with pip (with optional namedparams dependencies):
-
-    # see 'Using named parameters' section below
-    pip install 'vertica-python[namedparams]'
-
 Source code for vertica-python can be found at:
 
     https://github.com/vertica/vertica-python
@@ -219,8 +214,6 @@ connection.close()
 **Query using named parameters**:
 
 ```python
-# Using named parameter bindings requires psycopg2>=2.5.1 which is not includes with the base vertica_python requirements.
-
 cur = connection.cursor()
 cur.execute("SELECT * FROM a_table WHERE a = :propA b = :propB", {'propA': 1, 'propB': 'stringValue'})
 

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,6 @@ setup(
         'future',
         'six>=1.10.0'
     ],
-    extras_require={'namedparams': ['psycopg2>=2.5.1']},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,5 @@ commands =
     nosetests {posargs}
 deps =
     nose==1.3.6
-    psycopg2>=2.5.1
     pytz
     python-dateutil

--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -382,6 +382,15 @@ class CursorTestCase(VerticaPythonIntegrationTestCase):
             formatted_word = u''.join((u'"', re.escape(bad_word), u'"'))
             self.assertEqual(formatted_word, cur.format_quote(bad_word, True))
 
+    def test_execute_parameter(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+            val = u"".join(chr(i) for i in range(1, 128))
+            cur.execute("SELECT :val",
+                        parameters={"val": val},
+                        use_prepared_statements=False)
+            self.assertEqual([val], cur.fetchone())
+
     def test_udtype(self):
         poly = "POLYGON ((1 2, 2 3, 3 1, 1 2))"
         line = "LINESTRING (42.1 71, 41.4 70, 41.3 72.9, 42.99 71.46, 44.47 73.21)"

--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -382,15 +382,6 @@ class CursorTestCase(VerticaPythonIntegrationTestCase):
             formatted_word = u''.join((u'"', re.escape(bad_word), u'"'))
             self.assertEqual(formatted_word, cur.format_quote(bad_word, True))
 
-    def test_execute_parameter(self):
-        with self._connect() as conn:
-            cur = conn.cursor()
-            val = u"".join(chr(i) for i in range(1, 128))
-            cur.execute("SELECT :val",
-                        parameters={"val": val},
-                        use_prepared_statements=False)
-            self.assertEqual([val], cur.fetchone())
-
     def test_udtype(self):
         poly = "POLYGON ((1 2, 2 3, 3 1, 1 2))"
         line = "LINESTRING (42.1 71, 41.4 70, 41.3 72.9, 42.99 71.46, 44.47 73.21)"
@@ -582,6 +573,14 @@ class SimpleQueryTestCase(VerticaPythonIntegrationTestCase):
             cur.execute("SELECT * FROM {}".format(self._table))
             res = cur.fetchall()
             self.assertListOfListsEqual(res, [values])
+
+    def test_execute_parameters(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+            all_chars = u"".join(chr(i) for i in range(1, 128))
+            backslash_data = u"\\backslash\\ \\data\\\\"
+            cur.execute("SELECT :a, :b", parameters={"a": all_chars, "b": backslash_data})
+            self.assertEqual([all_chars, backslash_data], cur.fetchone())
 
 
 class SimpleQueryExecutemanyTestCase(VerticaPythonIntegrationTestCase):

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -455,7 +455,7 @@ class Cursor(object):
         if is_csv:
             return u'"{0}"'.format(re.escape(param))
         else:
-            return u"'{0}'".format(param.replace(u"'", u"''"))
+            return u"'{0}'".format(param.replace(u"'", u"''").replace(u"\\", u"\\\\"))
 
     def _execute_simple_query(self, query):
         """

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -51,13 +51,6 @@ import six
 from builtins import str
 from six import binary_type, text_type, string_types, BytesIO, StringIO
 
-try:
-    from psycopg2.extensions import QuotedString
-except ImportError:
-    class QuotedString(object):
-        def __init__(self, s):
-            raise ImportError("couldn't import psycopg2.extensions.QuotedString")
-
 from .. import errors
 from ..compat import as_text
 from ..vertica import messages
@@ -459,11 +452,10 @@ class Cursor(object):
         return operation
 
     def format_quote(self, param, is_csv):
-        # TODO Make sure adapt() behaves properly
         if is_csv:
             return u'"{0}"'.format(re.escape(param))
         else:
-            return QuotedString(param.encode(UTF_8, self.unicode_error)).getquoted()
+            return u"'{0}'".format(param.replace(u"'", u"''"))
 
     def _execute_simple_query(self, query):
         """


### PR DESCRIPTION
- It was only used to format client-side string named parameters, for a
relatively trivial operation
- Remove all mentions of it in documentation
- Remove 'namedparams' extras requirement