### PR TITLE
Fix #272 Make THROW_ERROR function throws an error

### DIFF
--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -350,6 +350,11 @@ class CursorTestCase(VerticaPythonIntegrationTestCase):
             with self.assertRaises(errors.QueryError):
                 cur.execute("SELECT * FROM {0}_fail".format(self._table))
 
+            # generate a user-defined error message
+            err_msg = 'USER GENERATED ERROR: test error'
+            with self.assertRaisesRegexp(errors.QueryError, err_msg):
+                cur.execute("SELECT THROW_ERROR('test error')")
+
             # verify cursor still usable after errors
             cur.execute("SELECT a, b FROM {0} WHERE a = 1".format(self._table))
             res = cur.fetchall()

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -487,6 +487,8 @@ class Cursor(object):
         elif isinstance(self._message, messages.RowDescription):
             self.description = [Column(fd, self.unicode_error) for fd in self._message.fields]
             self._message = self.connection.read_message()
+            if isinstance(self._message, messages.ErrorResponse):
+                raise errors.QueryError.from_error_response(self._message, query)
 
     def _error_handler(self, msg):
         self.connection.write(messages.Sync())


### PR DESCRIPTION
Old behavior:
When executing a sql containing the THROW_ERROR function, `cursor.execute()` does NOT throw an error. This happens only when `use_prepared_statements=False`. An error is thrown after `cursor.fetch*()` is called. 

New behavior:
No matter `use_prepared_statements=True/False`, `cursor.execute()` always throw an error when the sql contains the THROW_ERROR function. No `cursor.fetch*()` is needed to retrieve the error.