### PR TITLE
Point to Python36 for SSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ connection = vertica_python.connect(**conn_info)
 
 ```
 
-See more on SSL options [here](https://docs.python.org/2/library/ssl.html).
+See more on SSL options [here](https://docs.python.org/3.6/library/ssl.html).
 
 Logging is disabled by default if you do not pass values to both ```log_level``` and ```log_path```.  The default value of ```log_level``` is logging.WARNING. You can find all levels [here](https://docs.python.org/3.6/library/logging.html#logging-levels). The default value of ```log_path``` is 'vertica_python.log', the log file will be in the current execution directory. For example,
 


### PR DESCRIPTION
Was looking at the docs for how to set up `ssl` and noticed that the `README` was pointing to Python2 for setting up `ssl`. Since end of life support for Python2 is 2020/01/01 it makes sense to redirect them to Python36 for this, the same way that they are already redirected to Python36 for log levels.