### PR TITLE
Fix bug where logging throws error with unicode characters.

### DIFF
--- a/vertica_python/vertica/log.py
+++ b/vertica_python/vertica/log.py
@@ -50,7 +50,7 @@ class VerticaLogging(object):
                  '%(message)s'.format(context)),
             datefmt='%Y-%m-%d %H:%M:%S')
         cls.ensure_dir_exists(logfile)
-        file_handler = logging.FileHandler(logfile)
+        file_handler = logging.FileHandler(logfile, encoding='utf-8')
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
         logger.setLevel(log_level)


### PR DESCRIPTION
On Windows 10 with python 3, logging sometimes throws an unexpected error when it receives a unicode character. Not it doesn't.