### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ conn_info = {'host': '127.0.0.1',
              # using server-side prepared statements is disabled by default
              'use_prepared_statements': False,
              # connection timeout is not enabled by default
-             # 5 seconds timeout for obtaining connection
+             # 5 seconds timeout for a socket operation (Establishing a connection or read/write operation)
              'connection_timeout': 5}
 
 # simple connection, with manual close

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ conn_info = {'host': '127.0.0.1',
              # using server-side prepared statements is disabled by default
              'use_prepared_statements': False,
              # connection timeout is not enabled by default
+             # 5 seconds timeout for obtaining connection
              'connection_timeout': 5}
 
 # simple connection, with manual close

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ conn_info = {'host': '127.0.0.1',
              # using server-side prepared statements is disabled by default
              'use_prepared_statements': False,
              # connection timeout is not enabled by default
-             # 5 seconds timeout for a socket operation (Establishing a connection or read/write operation)
+             # 5 seconds timeout for a socket operation (Establishing a TCP connection or read/write operation)
              'connection_timeout': 5}
 
 # simple connection, with manual close


### PR DESCRIPTION
Unit of connection_timeout field is missing from the docs

This PR adds the unit for connection_timeout parameter in the readme