### PR TITLE
Connect using connection string #195

### DIFF
--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -35,7 +35,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-from .vertica.connection import Connection, connect
+from .vertica.connection import Connection, connect, parse_dsn
 
 # Importing exceptions for compatibility with dbapi 2.0.
 # See: PEP 249 - Python Database API 2.0
@@ -51,7 +51,7 @@ __copyright__ = 'Copyright (c) 2018-2019 Micro Focus or one of its affiliates.'
 __license__ = 'Apache 2.0'
 
 __all__ = ['Connection', 'PROTOCOL_VERSION', 'version_info', 'apilevel', 'threadsafety',
-           'paramstyle', 'connect', 'Error', 'Warning', 'DataError', 'DatabaseError',
+           'paramstyle', 'connect', 'parse_dsn', 'Error', 'Warning', 'DataError', 'DatabaseError',
            'IntegrityError', 'InterfaceError', 'InternalError', 'NotSupportedError',
            'OperationalError', 'ProgrammingError']
 

--- a/vertica_python/tests/unit_tests/test_parsedsn.py
+++ b/vertica_python/tests/unit_tests/test_parsedsn.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2018-2019 Micro Focus or one of its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import print_function, division, absolute_import
+
+from .base import VerticaPythonUnitTestCase
+from ...vertica.connection import parse_dsn
+
+
+class ParseDSNTestCase(VerticaPythonUnitTestCase):
+    def test_basic(self):
+        dsn = 'vertica://mike@127.0.0.1/db1'
+        expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1'}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
+        dsn = 'vertica://john:pwd@example.com:5433/db1'
+        expected = {'database': 'db1', 'host': 'example.com', 'password': 'pwd',
+                    'port': 5433, 'user': 'john'}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
+    def test_str_arguments(self):
+        dsn = ('vertica://john:pwd@localhost:5433/db1?'
+               'session_label=vpclient&unicode_error=strict&'
+               'log_path=/home/admin/vClient.log&log_level=DEBUG')
+        expected = {'database': 'db1', 'host': 'localhost', 'user': 'john',
+                    'password': 'pwd', 'port': 5433, 'log_level': 'DEBUG',
+                    'session_label': 'vpclient', 'unicode_error': 'strict',
+                    'log_path': '/home/admin/vClient.log' }
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
+    def test_boolean_arguments(self):
+        dsn = ('vertica://mike@127.0.0.1/db1?connection_load_balance=True&'
+               'use_prepared_statements=0&ssl=false')
+        expected = {'database': 'db1', 'connection_load_balance': True,
+                    'use_prepared_statements': False,  'ssl': False,
+                    'host': '127.0.0.1', 'user': 'mike'}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
+    def test_number_arguments(self):
+        dsn = 'vertica://mike@127.0.0.1/db1?connection_timeout=1.5&log_level=10'
+        expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1',
+                    'connection_timeout': 1.5, 'log_level': 10}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
+    def test_ignored_arguments(self):
+        # Invalid value
+        dsn = ('vertica://mike@127.0.0.1/db1?ssl=ssl_context&'
+               'connection_load_balance=unknown')
+        expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1'}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
+        # Unsupported argument
+        dsn = 'vertica://mike@127.0.0.1/db1?backup_server_node=123.456.789.123'
+        expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1'}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
+    def test_overwrite_arguments(self):
+        dsn = 'vertica://mike@127.0.0.1/db1?ssl=on&ssl=off&ssl=1&ssl=0'
+        expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1',
+                    'ssl': False}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+    

--- a/vertica_python/tests/unit_tests/test_parsedsn.py
+++ b/vertica_python/tests/unit_tests/test_parsedsn.py
@@ -21,6 +21,11 @@ from ...vertica.connection import parse_dsn
 
 class ParseDSNTestCase(VerticaPythonUnitTestCase):
     def test_basic(self):
+        dsn = 'vertica://admin@192.168.10.1'
+        expected = {'host': '192.168.10.1', 'user': 'admin'}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)
+
         dsn = 'vertica://mike@127.0.0.1/db1'
         expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1'}
         parsed = parse_dsn(dsn)
@@ -52,7 +57,7 @@ class ParseDSNTestCase(VerticaPythonUnitTestCase):
         parsed = parse_dsn(dsn)
         self.assertDictEqual(expected, parsed)
 
-    def test_number_arguments(self):
+    def test_numeric_arguments(self):
         dsn = 'vertica://mike@127.0.0.1/db1?connection_timeout=1.5&log_level=10'
         expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1',
                     'connection_timeout': 1.5, 'log_level': 10}

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -46,7 +46,12 @@ from collections import deque
 
 # noinspection PyCompatibility,PyUnresolvedReferences
 from builtins import str
-from six import raise_from, string_types, integer_types
+from six import raise_from, string_types, integer_types, PY2
+
+if PY2:
+    from urlparse import urlparse, parse_qs
+else:
+    from urllib.parse import urlparse, parse_qs
 
 import vertica_python
 from .. import errors
@@ -71,6 +76,41 @@ except Exception as e:
 def connect(**kwargs):
     """Opens a new connection to a Vertica database."""
     return Connection(kwargs)
+
+
+def parse_dsn(dsn):
+    """Parse connection string into a dictionary of keywords and values.
+       Connection string format:
+           vertica://<user>:<password>@<host>:<port>/<database>?k1=v1&k2=v2
+    """
+    url = urlparse(dsn)
+    if url.scheme != 'vertica':
+        raise ValueError("Only vertica:// scheme is supported.")
+
+    result = {k: v for k, v in (
+        ('host', url.hostname),
+        ('port', url.port),
+        ('user', url.username),
+        ('password', url.password),
+        ('database', url.path[1:])) if v is not None
+    }
+    for key, value in parse_qs(url.query).items():
+        if key == 'backup_server_node':
+            continue
+        elif key in ('connection_load_balance', 'use_prepared_statements', 'ssl'):
+            lower = value[-1].lower()
+            if lower in ('true', 'on', '1'):
+                result[key] = True
+            elif lower in ('false', 'off', '0'):
+                result[key] = False
+        elif key == 'connection_timeout':
+            result[key] = float(value[-1])
+        elif key == 'log_level':
+            result[key] = int(value[-1])
+        else:
+            result[key] = value[-1]
+
+    return result
 
 
 class _AddressList(object):
@@ -184,7 +224,10 @@ class Connection(object):
         self.socket = None
 
         options = options or {}
-        self.options = {key: value for key, value in options.items() if value is not None}
+        # Data source name as string
+        self.options = parse_dsn(options['dsn']) if 'dsn' in options else {}
+        self.options.update({key: value for key, value in options.items() \
+                             if key != 'dsn' and value is not None})
 
         # Set up connection logger
         logger_name = 'vertica_{0}_{1}'.format(id(self), str(uuid.uuid4())) # must be a unique value


### PR DESCRIPTION
This PR replaces inactive PR #196 (credit to @bourbaki) to implement #195.

Add keyword parameter `dsn` to `vertica_python.connect()`.
Add new function `vertica_python.parse_dsn(connection_str)`.