### PR TITLE
WIP: Friendly errors

### DIFF
--- a/vertica_python/errors.py
+++ b/vertica_python/errors.py
@@ -114,7 +114,8 @@ class QueryError(ProgrammingError):
         self.sql = sql
         ProgrammingError.__init__(self,
                                   "{0}, SQL: {1}".format(error_response.error_message(),
-                                                         repr(self.one_line_sql())))
+                                                         repr(self.one_line_sql())),
+                                  error_response.attributes)
 
     def one_line_sql(self):
         if self.sql:

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -559,7 +559,7 @@ class Connection(object):
             if error_handler is not None:
                 error_handler(message)
             else:
-                raise errors.DatabaseError(message.error_message())
+                raise errors.DatabaseError(message.error_message(), message.attributes)
         else:
             msg = 'Received unexpected message type: {}. '.format(type(message).__name__)
             if isinstance(expected_types, tuple):
@@ -622,7 +622,7 @@ class Connection(object):
                 break
             elif isinstance(message, messages.ErrorResponse):
                 self._logger.error(message.error_message())
-                raise errors.ConnectionError(message.error_message())
+                raise errors.ConnectionError(message.error_message(), message.attributes)
             else:
                 msg = "Received unexpected startup message: {0}".format(message)
                 self._logger.error(msg)

--- a/vertica_python/vertica/messages/backend_messages/notice_response.py
+++ b/vertica_python/vertica/messages/backend_messages/notice_response.py
@@ -63,6 +63,7 @@ class NoticeResponse(BackendMessage):
     def __init__(self, data):
         BackendMessage.__init__(self)
         self.values = {}
+        self.attributes = {}
 
         pos = 0
         while pos < len(data) - 1:
@@ -79,7 +80,9 @@ class NoticeResponse(BackendMessage):
         # May want to break out into a function at some point
         for field_def in FIELD_DEFINITIONS:
             if self.values.get(field_def['name'], None) is not None:
-                setattr(self, field_def['attribute'], self.values[field_def['name']])
+                attr, value = field_def['attribute'], self.values[field_def['name']]
+                setattr(self, attr, value)
+                self.attributes[attr] = value
 
     def error_message(self):
         ordered = []

--- a/vertica_python/vertica/messages/backend_messages/notice_response.py
+++ b/vertica_python/vertica/messages/backend_messages/notice_response.py
@@ -70,7 +70,8 @@ class NoticeResponse(BackendMessage):
 
             unpacked = unpack_from('c{0}sx'.format(null_byte - 1 - pos), data, pos)
             key = unpacked[0]
-            value = unpacked[1]
+            raw_value = unpacked[1]
+            value = raw_value.decode('utf-8') if type(raw_value) == bytes else raw_value
 
             self.values[FIELD_NAMES[key]] = value
             pos += (len(value) + 2)


### PR DESCRIPTION
Beginning of a solution for #312 

1. Decode fields parsed in `NoticeResponse()` (to prevent `b''` rows wrapping in Python 3).
1. Add `attributes` dict to have an individual access to message fields.
1. Pass `attributes` to Exceptions to have access in `except` like in example below:

```python
In [6]: conn = vertica_python.connect(**conn_args) 
   ...:  
   ...: try: 
   ...:     conn.cursor().execute('Nope') 
   ...: except Exception as e: 
   ...:     print(e) 
   ...:     print(e.args[1]) 
   ...:     print(e.args[1].get('sqlstate')) 
   ...:                                                                                                                                                                       
('Severity: ERROR, Message: Syntax error at or near "Nope", Sqlstate: 42601, Position: 1, Routine: base_yyerror, File: /data/qb_workspaces/jenkins2/ReleaseBuilds/Grader/REL-9_2_1-x_grader/build/vertica/Parser/scan.l, Line: 1043, Error Code: 4856, SQL: \'Nope\'', {'severity': 'ERROR', 'message': 'Syntax error at or near "Nope"', 'sqlstate': '42601', 'position': '1', 'routine': 'base_yyerror', 'file': '/data/qb_workspaces/jenkins2/ReleaseBuilds/Grader/REL-9_2_1-x_grader/build/vertica/Parser/scan.l', 'line': '1043', 'error_code': '4856'})
{'severity': 'ERROR', 'message': 'Syntax error at or near "Nope"', 'sqlstate': '42601', 'position': '1', 'routine': 'base_yyerror', 'file': '/data/qb_workspaces/jenkins2/ReleaseBuilds/Grader/REL-9_2_1-x_grader/build/vertica/Parser/scan.l', 'line': '1043', 'error_code': '4856'}
42601
```