### PR TITLE
Decode notice messages

### DIFF
--- a/vertica_python/errors.py
+++ b/vertica_python/errors.py
@@ -187,18 +187,18 @@ class LostConnectivityFailure(QueryError):
 
 
 QUERY_ERROR_CLASSES = {
-    b'55V03': LockFailure,
-    b'53000': InsufficientResources,
-    b'53200': OutOfMemory,
-    b'42601': VerticaSyntaxError,
-    b'3F000': MissingSchema,
-    b'42V01': MissingRelation,
-    b'42703': MissingColumn,
-    b'22V04': CopyRejected,
-    b'42501': PermissionDenied,
-    b'22007': InvalidDatetimeFormat,
-    b'42710': DuplicateObject,
-    b'57014': QueryCanceled,
-    b'08006': ConnectionFailure,
-    b'V1001': LostConnectivityFailure
+    '55V03': LockFailure,
+    '53000': InsufficientResources,
+    '53200': OutOfMemory,
+    '42601': VerticaSyntaxError,
+    '3F000': MissingSchema,
+    '42V01': MissingRelation,
+    '42703': MissingColumn,
+    '22V04': CopyRejected,
+    '42501': PermissionDenied,
+    '22007': InvalidDatetimeFormat,
+    '42710': DuplicateObject,
+    '57014': QueryCanceled,
+    '08006': ConnectionFailure,
+    'V1001': LostConnectivityFailure
 }

--- a/vertica_python/vertica/messages/backend_messages/notice_response.py
+++ b/vertica_python/vertica/messages/backend_messages/notice_response.py
@@ -72,7 +72,7 @@ class NoticeResponse(BackendMessage):
             key = unpacked[0]
             value = unpacked[1]
 
-            self.values[FIELD_NAMES[key]] = value
+            self.values[FIELD_NAMES[key]] = value.decode('utf-8')
             pos += (len(value) + 2)
 
         # May want to break out into a function at some point


### PR DESCRIPTION
#312: Improve notice messages in Python 3, remove `b'...'` format.

Previously: `Severity: b'FATAL', Message: b'Invalid username or password', ..., Line: b'1061', Error Code: b'3781'`
Now: `Severity: FATAL, Message: Invalid username or password, ..., Line: 1061, Error Code: 3781`