### PR TITLE
Add python3.8 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ services:
 matrix:
   include:
     - python: 3.8
+      dist: xenial
+      sudo: true
       env: TOXENV=py38
     - python: 3.7
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ services:
 
 matrix:
   include:
+    - python: 3.8
+      env: TOXENV=py38
     - python: 3.7
       dist: xenial
       sudo: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 language: python
 
 services:
@@ -7,12 +7,8 @@ services:
 matrix:
   include:
     - python: 3.8
-      dist: xenial
-      sudo: true
       env: TOXENV=py38
     - python: 3.7
-      dist: xenial
-      sudo: true
       env: TOXENV=py37
     - python: 3.6
       env: TOXENV=py36

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Database",
         "Topic :: Database :: Database Engines/Servers",
         "Operating System :: OS Independent"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py27,py34,py35,py36,py37,py38
 
 [testenv]
 passenv = *


### PR DESCRIPTION
Python 3.8 was released on October 14th, 2019. Add tests for this new version.