### PR TITLE
Replace pytz with python-dateutil

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ vertica-python has been tested with Vertica 9.1.1 and Python 2.7/3.4/3.5/3.6/3.7
 
 ## Installation
 
-If you're using pip >= 1.4 and you don't already have pytz installed:
-
-    pip install --pre pytz
-
 If you're using pip >= 1.4 and you don't already have python-dateutil installed:
 
     pip install --pre python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
     license="Apache License 2.0",
     install_requires=[
         'python-dateutil>=1.5',
-        'pytz',
         'future',
         'six>=1.10.0'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,4 @@ commands =
     nosetests {posargs}
 deps =
     nose==1.3.6
-    pytz
     python-dateutil

--- a/vertica_python/tests/integration_tests/test_timezones.py
+++ b/vertica_python/tests/integration_tests/test_timezones.py
@@ -37,7 +37,7 @@ from __future__ import print_function, division, absolute_import
 
 from collections import namedtuple
 from datetime import datetime
-import pytz
+from dateutil import tz
 
 from .base import VerticaPythonIntegrationTestCase
 
@@ -70,7 +70,7 @@ class TimeZoneTestCase(VerticaPythonIntegrationTestCase):
             TimeZoneTestingCase(
                 string='2016-05-15 13:15:17.789 UTC', template=template,
                 timestamp=datetime(year=2016, month=5, day=15, hour=13, minute=15, second=17,
-                                   microsecond=789000, tzinfo=pytz.utc)
+                                   microsecond=789000, tzinfo=tz.tzutc())
             ),
         ]
         self._test_ts(test_cases=test_cases)
@@ -81,7 +81,7 @@ class TimeZoneTestCase(VerticaPythonIntegrationTestCase):
             TimeZoneTestingCase(
                 string='2016-05-15 13:15:17.789 UTC', template=template,
                 timestamp=datetime(year=2016, month=5, day=15, hour=13, minute=15, second=17,
-                                   microsecond=789000, tzinfo=pytz.utc)
+                                   microsecond=789000, tzinfo=tz.tzutc())
             ),
         ]
         self._test_ts(test_cases=test_cases)

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -41,10 +41,9 @@ from collections import namedtuple
 from datetime import date, datetime
 from decimal import Decimal
 
-import pytz
 # noinspection PyCompatibility,PyUnresolvedReferences
 from builtins import str
-from dateutil import parser
+from dateutil import parser, tz
 
 from .. import errors
 from .. import datatypes
@@ -107,7 +106,7 @@ def timestamp_tz_parse(s):
     if s.endswith('+00'):
         # remove time zone
         ts = timestamp_parse(s[:-3].encode(encoding='utf-8', errors='strict'))
-        ts = ts.replace(tzinfo=pytz.UTC)
+        ts = ts.replace(tzinfo=tz.tzutc())
         return ts
     # other wise do a real parse (slower)
     return parser.parse(s)


### PR DESCRIPTION
vertica-python only leverages pytz for its `pytz.utc` `tzinfo` object, whereas python-dateutil is used for parsing timestamp strings.

Since python-dateutil also provides a `dateutil.tz.tzutc()` `tzinfo` object, replace `pytz.utc` with `dateutil.tz.tzutc()` and remove vertica-python's dependency on pytz. This reduces the number of dependencies on third-party datetime extension libraries from two to one.

This has an additional side benefit. Now, when `vertica_python/vertica/column.py:timestamp_tz_parse` parses a string corresponding to a timezone-aware datetime, the returned datetime's `tzinfo` is always generated by python-dateutil. Previously, in the special case where the string ended with `+00`, pytz would generate the returned datetime's `tzinfo`.

Resolves #322.