### PR TITLE
Allow logging without file

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ with vertica_python.connect(**conn_info) as conn:
     # do things
 ```
 
-Logging is disabled by default if you do not pass values to both ```log_level``` and ```log_path```.  The default value of ```log_level``` is logging.WARNING. You can find all levels [here](https://docs.python.org/3.8/library/logging.html#logging-levels). The default value of ```log_path``` is 'vertica_python.log', the log file will be in the current execution directory. For example,
+Logging is disabled by default if you do not pass values to both ```log_level``` and ```log_path```.  The default value of ```log_level``` is logging.WARNING. You can find all levels [here](https://docs.python.org/3.8/library/logging.html#logging-levels). The default value of ```log_path``` is 'vertica_python.log', the log file will be in the current execution directory. If ```log_path``` is set to ```None``` no file handler is set, logs will be processed by root handlers. For example,
 
 ```python
 import vertica_python
@@ -152,6 +152,17 @@ conn_info = {'host': '127.0.0.1',
              'log_path': '/home/admin/logs/vClient.log'}
 with vertica_python.connect(**conn_info) as connection:
    # do things
+
+## Example 4: use root handlers to process logs by setting 'log_path' to 'None' 
+conn_info = {'host': '127.0.0.1',
+             'port': 5433,
+             'user': 'some_user',
+             'password': 'some_password',
+             'database': 'a_database',
+             'log_level': logging.DEBUG,
+             'log_path': None}
+with vertica_python.connect(**conn_info) as connection:
+    # do things
 ```
 
 Connection Failover: Supply a list of backup hosts to ```backup_server_node``` for the client to try if the primary host you specify in the connection parameters (```host```, ```port```) is unreachable. Each item in the list should be either a host string (using default port 5433) or a (host, port) tuple. A host can be a host name or an IP address.

--- a/vertica_python/tests/common/base.py
+++ b/vertica_python/tests/common/base.py
@@ -121,7 +121,7 @@ class VerticaPythonTestCase(unittest.TestCase):
 
         testfile = os.path.splitext(os.path.basename(inspect.getsourcefile(cls)))[0]
         logfile = os.path.join(log_dir, tag, testfile + '.log')
-        VerticaLogging.setup_file_logging(cls.__name__, logfile, log_level, cls.__name__)
+        VerticaLogging.setup_logging(cls.__name__, logfile, log_level, cls.__name__)
         cls.logger = logging.getLogger(cls.__name__)
         return logfile
 

--- a/vertica_python/tests/unit_tests/test_logging.py
+++ b/vertica_python/tests/unit_tests/test_logging.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2019 Micro Focus or one of its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import print_function, division, absolute_import
+
+import logging
+import os
+
+from ...vertica.log import VerticaLogging
+from .base import VerticaPythonUnitTestCase
+
+
+class LoggingTestCase(VerticaPythonUnitTestCase):
+
+    def test_file_handler(self):
+        logger_name = "test_file_handler"
+
+        logger = logging.getLogger(logger_name)
+        self.assertNotEqual(logging.getLevelName(logger.getEffectiveLevel()), 'DEBUG')
+
+        log_file = os.path.join(self.test_config['log_dir'], 'test_file_handler.log')
+        VerticaLogging.setup_logging(logger_name, log_file, 'DEBUG')
+
+        self.assertEqual(len(logger.handlers), 1)
+        self.assertEqual(logging.getLevelName(logger.getEffectiveLevel()), 'DEBUG')
+
+    def test_missing_file(self):
+        logger_name = "test_missing_file"
+        logger = logging.getLogger(logger_name)
+
+        VerticaLogging.setup_logging(logger_name, None, 'DEBUG')
+
+        self.assertEqual(len(logger.handlers), 0)
+        self.assertEqual(logging.getLevelName(logger.getEffectiveLevel()), 'DEBUG')

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -246,8 +246,8 @@ class Connection(object):
         else:
             self.options.setdefault('log_level', DEFAULT_LOG_LEVEL)
             self.options.setdefault('log_path', DEFAULT_LOG_PATH)
-            VerticaLogging.setup_file_logging(logger_name, self.options['log_path'],
-                                              self.options['log_level'], id(self))
+            VerticaLogging.setup_logging(logger_name, self.options['log_path'],
+                                         self.options['log_level'], id(self))
 
         self.options.setdefault('host', DEFAULT_HOST)
         self.options.setdefault('port', DEFAULT_PORT)

--- a/vertica_python/vertica/log.py
+++ b/vertica_python/vertica/log.py
@@ -44,18 +44,20 @@ import logging
 class VerticaLogging(object):
 
     @classmethod
-    def setup_file_logging(cls, logger_name, logfile, log_level=logging.INFO, context=''):
+    def setup_logging(cls, logger_name, logfile, log_level=logging.INFO, context=''):
         logger = logging.getLogger(logger_name)
-        formatter = logging.Formatter(
-            fmt=('%(asctime)s.%(msecs)03d [%(module)s] '
-                 '{}/%(process)d:0x%(thread)x <%(levelname)s> '
-                 '%(message)s'.format(context)),
-            datefmt='%Y-%m-%d %H:%M:%S')
-        cls.ensure_dir_exists(logfile)
-        file_handler = logging.FileHandler(logfile, encoding='utf-8')
-        file_handler.setFormatter(formatter)
-        logger.addHandler(file_handler)
         logger.setLevel(log_level)
+
+        if logfile:
+            formatter = logging.Formatter(
+                fmt=('%(asctime)s.%(msecs)03d [%(module)s] '
+                     '{}/%(process)d:0x%(thread)x <%(levelname)s> '
+                     '%(message)s'.format(context)),
+                datefmt='%Y-%m-%d %H:%M:%S')
+            cls.ensure_dir_exists(logfile)
+            file_handler = logging.FileHandler(logfile, encoding='utf-8')
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
 
     @classmethod
     def ensure_dir_exists(cls, filepath):


### PR DESCRIPTION
## Description

Allow logging without file, if `log_path` is set to `None` then do not set up the file handler.

Address this issue: https://github.com/vertica/vertica-python/issues/340

## Motivation

In some cases, we just want to enable the logger, but we don't want to log to a file and use the root logger handlers instead. Example [in this case](https://github.com/DataDog/integrations-core/pull/5011/files#diff-d892d1977dccc10bbbdcebf1a63dd61cR567-R569) we had to redirect the output to `os. devnull`.