### PR TITLE
Fix quoting issue with client-side %s parameters

### DIFF
--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -654,6 +654,14 @@ class SimpleQueryTestCase(VerticaPythonIntegrationTestCase):
             cur.execute("SELECT :a, :b", parameters={"a": all_chars, "b": backslash_data})
             self.assertEqual([all_chars, backslash_data], cur.fetchone())
 
+    def test_execute_percent_parameters(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+            all_chars = u"".join(chr(i) for i in range(1, 128))
+            backslash_data = u"\\backslash\\ \\data\\\\"
+            cur.execute("SELECT %s, %s", parameters=[all_chars, backslash_data])
+            self.assertEqual([all_chars, backslash_data], cur.fetchone())
+
 
 class SimpleQueryExecutemanyTestCase(VerticaPythonIntegrationTestCase):
     def setUp(self):

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -484,7 +484,7 @@ class Cursor(object):
                 # Using a regex with word boundary to correctly handle params with similar names
                 # such as :s and :start
                 match_str = u":{0}\\b".format(key)
-                operation = re.sub(match_str, value, operation, flags=re.U)
+                operation = re.sub(match_str, lambda _: value, operation, flags=re.U)
 
         elif isinstance(parameters, (tuple, list)):
             tlist = []
@@ -511,7 +511,7 @@ class Cursor(object):
         if is_csv:
             return u'"{0}"'.format(re.escape(param))
         else:
-            return u"'{0}'".format(param.replace(u"'", u"''").replace(u"\\", u"\\\\"))
+            return u"'{0}'".format(param.replace(u"'", u"''"))
 
     def _execute_simple_query(self, query):
         """


### PR DESCRIPTION
Backslash quoting was used to escape for `re.sub`, used by :var style
placeholders. This was inappropriate for % style placeholders.

This change replaces blackslash quoting with `re.escape` for :var style
replaceholders and leaves % style values unchanged (except for the
necessary '' quoting, which remains in place.)