### PR TITLE
Fix #330: Remove future dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
-future
 pytest
 pytest-timeout
 python-dateutil

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,6 @@ setup(
     license="Apache License 2.0",
     install_requires=[
         'python-dateutil>=1.5',
-        'future',
         'six>=1.10.0'
     ],
     classifiers=[

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -43,7 +43,6 @@ from decimal import Decimal
 from uuid import UUID
 
 # noinspection PyCompatibility,PyUnresolvedReferences
-from builtins import str
 from dateutil import parser, tz
 
 from .. import errors
@@ -142,19 +141,19 @@ def vertica_type_cast(type_code, unicode_error):
         VerticaType.BOOL: lambda s: s == b't',
         VerticaType.INT8: lambda s: int(s),
         VerticaType.FLOAT8: lambda s: float(s),
-        VerticaType.CHAR: lambda s: str(s, encoding='utf-8', errors=unicode_error),
-        VerticaType.VARCHAR: lambda s: str(s, encoding='utf-8', errors=unicode_error),
+        VerticaType.CHAR: lambda s: s.decode('utf-8', unicode_error),
+        VerticaType.VARCHAR: lambda s: s.decode('utf-8', unicode_error),
         VerticaType.DATE: date_parse,
         VerticaType.TIME: time_parse,
         VerticaType.TIMESTAMP: timestamp_parse,
         VerticaType.TIMESTAMPTZ: timestamp_tz_parse,
         VerticaType.INTERVAL: None,
         VerticaType.TIMETZ: None,
-        VerticaType.NUMERIC: lambda s: Decimal(str(s, encoding='utf-8', errors=unicode_error)),
+        VerticaType.NUMERIC: lambda s: Decimal(s.decode('utf-8', unicode_error)),
         VerticaType.VARBINARY: None,
-        VerticaType.UUID: lambda s: UUID(str(s, encoding='utf-8', errors=unicode_error)),
+        VerticaType.UUID: lambda s: UUID(s.decode('utf-8', unicode_error)),
         VerticaType.INTERVALYM: None,
-        VerticaType.LONGVARCHAR: lambda s: str(s, encoding='utf-8', errors=unicode_error),
+        VerticaType.LONGVARCHAR: lambda s: s.decode('utf-8', unicode_error),
         VerticaType.LONGVARBINARY: None,
         VerticaType.BINARY: None
     }

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -46,7 +46,6 @@ from struct import unpack
 from collections import deque, namedtuple
 
 # noinspection PyCompatibility,PyUnresolvedReferences
-from builtins import str
 from six import raise_from, string_types, integer_types, PY2
 
 if PY2:

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -53,7 +53,6 @@ except ImportError:
 
 import six
 # noinspection PyUnresolvedReferences,PyCompatibility
-from builtins import str
 from six import binary_type, text_type, string_types, BytesIO, StringIO
 
 from .. import errors


### PR DESCRIPTION
- Remove `builtins` usage, so in Python 2.7, CHAR/VARCHAR type data will be returned as `unicode` rather than `<class 'future.types.newstr.newstr'>`
- Remove `future` dependency in setup.py and requirements-dev.txt