### PR TITLE
Fix log path doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ with vertica_python.connect(**conn_info) as conn:
     # do things
 ```
 
-Logging is disabled by default if you do not pass values to both ```log_level``` and ```log_path```.  The default value of ```log_level``` is logging.WARNING. You can find all levels [here](https://docs.python.org/3.8/library/logging.html#logging-levels). The default value of ```log_path``` is 'vertica_python.log', the log file will be in the current execution directory. If ```log_path``` is set to ```None``` no file handler is set, logs will be processed by root handlers. For example,
+Logging is disabled by default if you do not pass values to both ```log_level``` and ```log_path```.  The default value of ```log_level``` is logging.WARNING. You can find all levels [here](https://docs.python.org/3.8/library/logging.html#logging-levels). The default value of ```log_path``` is 'vertica_python.log', the log file will be in the current execution directory. If ```log_path``` is set to ```''``` (empty string) no file handler is set, logs will be processed by root handlers. For example,
 
 ```python
 import vertica_python
@@ -153,14 +153,14 @@ conn_info = {'host': '127.0.0.1',
 with vertica_python.connect(**conn_info) as connection:
    # do things
 
-## Example 4: use root handlers to process logs by setting 'log_path' to 'None' 
+## Example 4: use root handlers to process logs by setting 'log_path' to '' (empty string) 
 conn_info = {'host': '127.0.0.1',
              'port': 5433,
              'user': 'some_user',
              'password': 'some_password',
              'database': 'a_database',
              'log_level': logging.DEBUG,
-             'log_path': None}
+             'log_path': ''}
 with vertica_python.connect(**conn_info) as connection:
     # do things
 ```

--- a/vertica_python/tests/unit_tests/test_logging.py
+++ b/vertica_python/tests/unit_tests/test_logging.py
@@ -40,6 +40,7 @@ class LoggingTestCase(VerticaPythonUnitTestCase):
         logger = logging.getLogger(logger_name)
 
         VerticaLogging.setup_logging(logger_name, None, 'DEBUG')
+        VerticaLogging.setup_logging(logger_name, '', 'DEBUG')
 
         self.assertEqual(len(logger.handlers), 0)
         self.assertEqual(logging.getLevelName(logger.getEffectiveLevel()), 'DEBUG')


### PR DESCRIPTION
## The issue 

When `log_path` is set  `None`, we expected that no file handler will be set. 

But the issue is that `log_path = None` is not passed because we filter out `None` values:

https://github.com/vertica/vertica-python/blob/9f51fc41642fc5ca398ef1207dbee9355bd3f74c/vertica_python/vertica/connection.py#L244-L245

then, the `DEFAULT_LOG_PATH` is used, which is not what we intend/want:

https://github.com/vertica/vertica-python/blob/9f51fc41642fc5ca398ef1207dbee9355bd3f74c/vertica_python/vertica/connection.py#L256

### Changing how `self.options ` is handled might not be an option

https://github.com/vertica/vertica-python/blob/9f51fc41642fc5ca398ef1207dbee9355bd3f74c/vertica_python/vertica/connection.py#L244-L245

If we let pass options with None value, this might break use cases where we want to pass None and expect default value to be populated. e.g. for `host`, `port`, etc

## Proposition

The simplest way to fix the issue, is to consider that if `log_path` is set to `''` (empty string), then we don't log a file.

Let me know if that sounds reasonable to you.

## Additional Notes

Related PR: https://github.com/vertica/vertica-python/pull/341