### PR TITLE
fix bug when log_path set to None

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ with vertica_python.connect(**conn_info) as conn:
     # do things
 ```
 
-Logging is disabled by default if you do not pass values to both ```log_level``` and ```log_path```.  The default value of ```log_level``` is logging.WARNING. You can find all levels [here](https://docs.python.org/3.8/library/logging.html#logging-levels). The default value of ```log_path``` is 'vertica_python.log', the log file will be in the current execution directory. If ```log_path``` is set to ```''``` (empty string) no file handler is set, logs will be processed by root handlers. For example,
+Logging is disabled by default if you do not pass values to both ```log_level``` and ```log_path```.  The default value of ```log_level``` is logging.WARNING. You can find all levels [here](https://docs.python.org/3.8/library/logging.html#logging-levels). The default value of ```log_path``` is 'vertica_python.log', the log file will be in the current execution directory. If ```log_path``` is set to ```''``` (empty string) or ```None```, no file handler is set, logs will be processed by root handlers. For example,
 
 ```python
 import vertica_python

--- a/vertica_python/tests/unit_tests/test_parsedsn.py
+++ b/vertica_python/tests/unit_tests/test_parsedsn.py
@@ -87,4 +87,11 @@ class ParseDSNTestCase(VerticaPythonUnitTestCase):
                     'ssl': False}
         parsed = parse_dsn(dsn)
         self.assertDictEqual(expected, parsed)
-    
+
+    def test_arguments_blank_values(self):
+        dsn = ('vertica://mike@127.0.0.1/db1?connection_timeout=1.5&log_path=&'
+               'ssl=&connection_timeout=2&log_path=&connection_timeout=')
+        expected = {'host': '127.0.0.1', 'user': 'mike', 'database': 'db1',
+                    'connection_timeout': 2.0, 'log_path': ''}
+        parsed = parse_dsn(dsn)
+        self.assertDictEqual(expected, parsed)

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -97,21 +97,30 @@ def parse_dsn(dsn):
         ('password', url.password),
         ('database', url.path[1:])) if v
     }
-    for key, value in parse_qs(url.query).items():
-        if key == 'backup_server_node':
+    for key, values in parse_qs(url.query, keep_blank_values=True).items():
+        # Try to get the last non-blank value in the list of values for each key
+        for i in reversed(range(len(values))):
+            value = values[i]
+            if value != '':
+                break
+
+        if value == '' and key != 'log_path':
+            # blank values are to be ignored
+            continue
+        elif key == 'backup_server_node':
             continue
         elif key in ('connection_load_balance', 'use_prepared_statements', 'ssl'):
-            lower = value[-1].lower()
+            lower = value.lower()
             if lower in ('true', 'on', '1'):
                 result[key] = True
             elif lower in ('false', 'off', '0'):
                 result[key] = False
         elif key == 'connection_timeout':
-            result[key] = float(value[-1])
-        elif key == 'log_level' and value[-1].isdigit():
-            result[key] = int(value[-1])
+            result[key] = float(value)
+        elif key == 'log_level' and value.isdigit():
+            result[key] = int(value)
         else:
-            result[key] = value[-1]
+            result[key] = value
 
     return result
 
@@ -242,7 +251,7 @@ class Connection(object):
         options = options or {}
         self.options = parse_dsn(options['dsn']) if 'dsn' in options else {}
         self.options.update({key: value for key, value in options.items() \
-                             if key != 'dsn' and value is not None})
+                             if key == 'log_path' or (key != 'dsn' and value is not None)})
 
         # Set up connection logger
         logger_name = 'vertica_{0}_{1}'.format(id(self), str(uuid.uuid4())) # must be a unique value


### PR DESCRIPTION
This is a follow-up fix for #352. 

Now when `log_path` is set to None, no file handler will be created.