### PR TITLE
fetchone() performance improvements

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -54,6 +54,7 @@ except ImportError:
 import six
 # noinspection PyUnresolvedReferences,PyCompatibility
 from six import binary_type, text_type, string_types, BytesIO, StringIO
+from six.moves import zip
 
 from .. import errors
 from ..compat import as_text
@@ -452,13 +453,13 @@ class Cursor(object):
 
     def format_row_as_dict(self, row_data):
         return OrderedDict(
-            (self.description[idx].name, self.description[idx].convert(value))
-            for idx, value in enumerate(row_data.values)
+            (descr.name, descr.convert(value))
+            for descr, value in zip(self.description, row_data.values)
         )
 
     def format_row_as_array(self, row_data):
-        return [self.description[idx].convert(value)
-                for idx, value in enumerate(row_data.values)]
+        return [descr.convert(value)
+                for descr, value in zip(self.description, row_data.values)]
 
     # noinspection PyArgumentList
     def format_operation_with_parameters(self, operation, parameters, is_csv=False):

--- a/vertica_python/vertica/messages/backend_messages/data_row.py
+++ b/vertica_python/vertica/messages/backend_messages/data_row.py
@@ -52,10 +52,10 @@ class DataRow(BackendMessage):
         pos = 2
 
         for i in range(field_count):
-            size = unpack_from('!I', data, pos)[0]
+            size = unpack_from('!i', data, pos)[0]
             pos += 4
 
-            if size > 0 and size != 4294967295:
+            if size != -1:
                 self.values[i] = unpack_from('{0}s'.format(size), data, pos)[0]
                 pos += size
 

--- a/vertica_python/vertica/messages/backend_messages/data_row.py
+++ b/vertica_python/vertica/messages/backend_messages/data_row.py
@@ -35,7 +35,7 @@
 
 from __future__ import print_function, division, absolute_import
 
-from struct import unpack, unpack_from
+from struct import unpack_from
 
 from six.moves import range
 
@@ -47,21 +47,17 @@ class DataRow(BackendMessage):
 
     def __init__(self, data):
         BackendMessage.__init__(self)
-        self.values = []
-        field_count = unpack('!H', data[0:2])[0]
+        field_count = unpack_from('!H', data, 0)[0]
+        self.values = [None] * field_count
         pos = 2
 
         for i in range(field_count):
             size = unpack_from('!I', data, pos)[0]
+            pos += 4
 
-            if size == 4294967295:
-                size = -1
-
-            if size == -1:
-                self.values.append(None)
-            else:
-                self.values.append(unpack_from('{0}s'.format(size), data, pos + 4)[0])
-            pos += (4 + max(size, 0))
+            if size > 0 and size != 4294967295:
+                self.values[i] = unpack_from('{0}s'.format(size), data, pos)[0]
+                pos += size
 
 
 BackendMessage.register(DataRow)


### PR DESCRIPTION
- Improve the performance of reading messages by using a bytearray to
read data or bytes when reading a single byte, instead of using bytes
and appending data to it (this affects more than only fetchone())
- Preallocate all values in the DataRow message