### PR TITLE
Further fetchone() performance improvement

### DIFF
--- a/vertica_python/compat.py
+++ b/vertica_python/compat.py
@@ -76,16 +76,16 @@ def as_bytes(bytes_or_text, encoding='utf-8'):
       bytes_or_text: A `bytes`, `bytearray`, `str`, or `unicode` object.
       encoding: A string indicating the charset for encoding unicode.
     Returns:
-      A `bytes` or `bytearray` object.
+      A `bytes` object.
     Raises:
       TypeError: If `bytes_or_text` is not a binary or unicode string.
     """
     if isinstance(bytes_or_text, _six.text_type):
         return bytes_or_text.encode(encoding)
-    elif _six.PY2 and isinstance(bytes_or_text, bytearray):
-        return bytes(bytes_or_text)  # Python 2 would expect an actual bytes (str) object
-    elif isinstance(bytes_or_text, (bytes, bytearray)):
-        return bytes_or_text  # Python 3 can use bytearray and bytes almost interchangeably
+    elif isinstance(bytes_or_text, bytearray):
+        return bytes(bytes_or_text)
+    elif isinstance(bytes_or_text, bytes):
+        return bytes_or_text
     else:
         raise TypeError('Expected binary or unicode string, got %r' %
                         (bytes_or_text,))

--- a/vertica_python/compat.py
+++ b/vertica_python/compat.py
@@ -82,8 +82,10 @@ def as_bytes(bytes_or_text, encoding='utf-8'):
     """
     if isinstance(bytes_or_text, _six.text_type):
         return bytes_or_text.encode(encoding)
+    elif _six.PY2 and isinstance(bytes_or_text, bytearray):
+        return bytes(bytes_or_text)  # Python 2 would expect an actual bytes (str) object
     elif isinstance(bytes_or_text, (bytes, bytearray)):
-        return bytes_or_text
+        return bytes_or_text  # Python 3 can use bytearray and bytes almost interchangeably
     else:
         raise TypeError('Expected binary or unicode string, got %r' %
                         (bytes_or_text,))

--- a/vertica_python/compat.py
+++ b/vertica_python/compat.py
@@ -73,16 +73,16 @@ import six as _six
 def as_bytes(bytes_or_text, encoding='utf-8'):
     """Converts either bytes or unicode to `bytes`, using utf-8 encoding for text.
     Args:
-      bytes_or_text: A `bytes`, `str`, or `unicode` object.
+      bytes_or_text: A `bytes`, `bytearray`, `str`, or `unicode` object.
       encoding: A string indicating the charset for encoding unicode.
     Returns:
-      A `bytes` object.
+      A `bytes` or `bytearray` object.
     Raises:
       TypeError: If `bytes_or_text` is not a binary or unicode string.
     """
     if isinstance(bytes_or_text, _six.text_type):
         return bytes_or_text.encode(encoding)
-    elif isinstance(bytes_or_text, bytes):
+    elif isinstance(bytes_or_text, (bytes, bytearray)):
         return bytes_or_text
     else:
         raise TypeError('Expected binary or unicode string, got %r' %
@@ -92,7 +92,7 @@ def as_bytes(bytes_or_text, encoding='utf-8'):
 def as_text(bytes_or_text, encoding='utf-8'):
     """Returns the given argument as a unicode string.
     Args:
-      bytes_or_text: A `bytes`, `str, or `unicode` object.
+      bytes_or_text: A `bytes`, `bytearray`, `str`, or `unicode` object.
       encoding: A string indicating the charset for decoding unicode.
     Returns:
       A `unicode` (Python 2) or `str` (Python 3) object.
@@ -101,7 +101,7 @@ def as_text(bytes_or_text, encoding='utf-8'):
     """
     if isinstance(bytes_or_text, _six.text_type):
         return bytes_or_text
-    elif isinstance(bytes_or_text, bytes):
+    elif isinstance(bytes_or_text, (bytes, bytearray)):
         return bytes_or_text.decode(encoding)
     else:
         raise TypeError('Expected binary or unicode string, got %r' % bytes_or_text)
@@ -121,14 +121,14 @@ def as_str_any(value):
     Returns:
       A `str` object.
     """
-    if isinstance(value, bytes):
+    if isinstance(value, (bytes, bytearray)):
         return as_str(value)
     else:
         return str(value)
 
 
 # Either bytes or text.
-bytes_or_text_types = (bytes, _six.text_type)
+bytes_or_text_types = (bytes, bytearray, _six.text_type)
 
 _allowed_symbols = [
     'as_str',

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -137,7 +137,7 @@ def time_parse(s):
 # Type casting of SQL types bytes representation into Python objects
 def vertica_type_cast(type_code, unicode_error):
     typecaster = {
-        VerticaType.UNKNOWN: None,
+        VerticaType.UNKNOWN: bytes,
         VerticaType.BOOL: lambda s: s == b't',
         VerticaType.INT8: lambda s: int(s),
         VerticaType.FLOAT8: lambda s: float(s),
@@ -147,17 +147,17 @@ def vertica_type_cast(type_code, unicode_error):
         VerticaType.TIME: time_parse,
         VerticaType.TIMESTAMP: timestamp_parse,
         VerticaType.TIMESTAMPTZ: timestamp_tz_parse,
-        VerticaType.INTERVAL: None,
-        VerticaType.TIMETZ: None,
+        VerticaType.INTERVAL: bytes,
+        VerticaType.TIMETZ: bytes,
         VerticaType.NUMERIC: lambda s: Decimal(s.decode('utf-8', unicode_error)),
-        VerticaType.VARBINARY: None,
+        VerticaType.VARBINARY: bytes,
         VerticaType.UUID: lambda s: UUID(s.decode('utf-8', unicode_error)),
-        VerticaType.INTERVALYM: None,
+        VerticaType.INTERVALYM: bytes,
         VerticaType.LONGVARCHAR: lambda s: s.decode('utf-8', unicode_error),
-        VerticaType.LONGVARBINARY: None,
-        VerticaType.BINARY: None
+        VerticaType.LONGVARBINARY: bytes,
+        VerticaType.BINARY: bytes
     }
-    return typecaster.get(type_code, None)
+    return typecaster.get(type_code, bytes)
 
 
 ColumnTuple = namedtuple('Column', ['name', 'type_code', 'display_size', 'internal_size',
@@ -183,7 +183,7 @@ class Column(object):
     def convert(self, s):
         if s is None:
             return
-        return self.converter(s) if self.converter is not None else s
+        return self.converter(s)
 
     def __str__(self):
         return as_str(str(self.props))

--- a/vertica_python/vertica/messages/backend_messages/data_row.py
+++ b/vertica_python/vertica/messages/backend_messages/data_row.py
@@ -56,7 +56,7 @@ class DataRow(BackendMessage):
             pos += 4
 
             if size != -1:
-                self.values[i] = unpack_from('{0}s'.format(size), data, pos)[0]
+                self.values[i] = data[pos : pos + size]
                 pos += size
 
 


### PR DESCRIPTION
- In `DataRow` message, use slicing on the `data` bytearray rather than
`unpack_from`, which saves from having to create the format string
- The value returned is now a `bytearray`, which means that the `compat`
module needs to handle `bytearray` in addition to `bytes`, considering them
as equivalent