### PR TITLE
Fix cursor.rowcount inconsistency for nextset

### DIFF
--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -618,11 +618,13 @@ class SimpleQueryTestCase(VerticaPythonIntegrationTestCase):
             cur.execute("SELECT 1; SELECT 'foo';")
 
             res1 = cur.fetchall()
+            self.assertEqual(cur.rowcount, 1)
             self.assertListOfListsEqual(res1, [[1]])
             self.assertIsNone(cur.fetchone())
             self.assertTrue(cur.nextset())
 
             res2 = cur.fetchall()
+            self.assertEqual(cur.rowcount, 1)
             self.assertListOfListsEqual(res2, [['foo']])
             self.assertIsNone(cur.fetchone())
             self.assertFalse(cur.nextset())

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -348,14 +348,17 @@ class Cursor(object):
                 self._message = self.connection.read_message()
                 if isinstance(self._message, messages.VerifyFiles):
                     self._handle_copy_local_protocol()
+                self.rowcount = -1
                 return True
             elif isinstance(self._message, messages.BindComplete):
                 self._message = self.connection.read_message()
+                self.rowcount = -1
                 return True
             elif isinstance(self._message, messages.ReadyForQuery):
                 return False
             elif isinstance(self._message, END_OF_RESULT_RESPONSES):
                 # result of a DDL/transaction
+                self.rowcount = -1
                 return True
             elif isinstance(self._message, messages.ErrorResponse):
                 raise errors.QueryError.from_error_response(self._message, self.operation)


### PR DESCRIPTION
#379 `cursor.rowcount` is counting incorrectly after calling `cursor.nextset()`.