### PR TITLE
Raise ConnectionError in connection.write

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -577,7 +577,10 @@ class Connection(object):
         except Exception as e:
             self.close_socket()
             self._logger.error(str(e))
-            raise
+            if isinstance(e, IOError):
+                raise_from(errors.ConnectionError(str(e)), e)
+            else:
+                raise
 
     def close_socket(self):
         try:


### PR DESCRIPTION
The 2 `Connection` methods most used by `Cursor` are `read_message` and `write`, however only `read_message` would tranform IO errors into DBAPI errors.
The main use case behind raising a DBAPI error instead of the raw error is to allow SqlAlchemy to better detect invalid connections in pre-ping (SqlAlchemy currently only catches DBAPI errors in the pre-ping).