### PR TITLE
Upgrade protocol version and server for testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Set up a Vertica server
         env:
-          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-10.1.0-0.x86_64.RHEL6.rpm"
+          VERTICA_CE_URL: "https://vertica-community-edition-for-testing.s3.amazonaws.com/XCz9cp7m/vertica-10.1.1-0.x86_64.RHEL6.rpm"
         run: |
           git clone https://github.com/jbfavre/docker-vertica.git
           curl $VERTICA_CE_URL --create-dirs -o docker-vertica/packages/vertica-ce.latest.rpm

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Please check out [release notes](https://github.com/vertica/vertica-python/releases) to learn about the latest improvements.
 
-vertica-python has been tested with Vertica 10.1 and Python 2.7/3.5/3.6/3.7/3.8/3.9. Feel free to submit issues and/or pull requests (Read up on our [contributing guidelines](#contributing-guidelines)).
+vertica-python has been tested with Vertica 10.1.1 and Python 2.7/3.5/3.6/3.7/3.8/3.9. Feel free to submit issues and/or pull requests (Read up on our [contributing guidelines](#contributing-guidelines)).
 
 
 ## Installation

--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -59,8 +59,8 @@ __all__ = ['Connection', 'PROTOCOL_VERSION', 'version_info', 'apilevel', 'thread
 version_info = (1, 0, 1)
 __version__ = '.'.join(map(str, version_info))
 
-# The protocol version (3.8) implemented in this library.
-PROTOCOL_VERSION = 3 << 16 | 8
+# The protocol version (3.9) implemented in this library.
+PROTOCOL_VERSION = 3 << 16 | 9
 
 apilevel = 2.0
 threadsafety = 1  # Threads may share the module, but not connections!


### PR DESCRIPTION
- upgrade server version to 10.1.1 for CI tests
- upgrade client supported protocol version from 3.8 to 3.9 (server behavior change, python client is unaffected)