### PR TITLE
Parsing text representation of [var]binary data sent by server

### DIFF
--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -1248,8 +1248,8 @@ class PreparedStatementTestCase(VerticaPythonIntegrationTestCase):
     def test_bind_binary(self):
         values = [b'binary data', b'\\backslash data\\', u'\\backslash data\\',
                   u'\u00f1 encoding', 'raw data', 'long varbinary data', None]
-        expected = [[b'binary data\\000\\000\\000', b'\\\\backslash data\\\\',
-                     b'\\\\backslash data\\\\', b'\\303\\261 encoding',
+        expected = [[b'binary data\x00\x00\x00', b'\\backslash data\\',
+                     b'\\backslash data\\', b'\xc3\xb1 encoding',
                      b'raw data', b'long varbinary data', None]]
         with self._connect() as conn:
             cur = conn.cursor()


### PR DESCRIPTION
When querying a BINARY/VARBINARY/LONG VARBINARY type value, data sent by server is the text representation of octal bytes.
- For a `\xxx` octal byte, text representation is 4 bytes. E.g. `\341` gives bytes(['`\\`', '`3`', '`4`', '`1`']).
- For an escaped `\`, text representation is 2 bytes. E.g. `\\` gives bytes(['`\\`', '`\\`']).
- For an ASCII character, it is the same as its text representation.

This fix parses the raw data from server and convert it back to binary.
Corresponding discussion for Go client: vertica/vertica-sql-go#87