### PR TITLE
Ver 78768

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -164,7 +164,7 @@ class _AddressList(object):
                            ' must be a host string or a (host, port) tuple')
                 self._logger.error(err_msg)
                 raise TypeError(err_msg)
-        random.shuffle(self.address_deque())
+        random.shuffle(self.address_deque)
         self._logger.debug('Address list: {0}'.format(list(self.address_deque)))
 
     def _append(self, host, port):

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -44,6 +44,7 @@ import getpass
 import uuid
 from struct import unpack
 from collections import deque, namedtuple
+import random
 
 # noinspection PyCompatibility,PyUnresolvedReferences
 from six import raise_from, string_types, integer_types, PY2
@@ -163,7 +164,7 @@ class _AddressList(object):
                            ' must be a host string or a (host, port) tuple')
                 self._logger.error(err_msg)
                 raise TypeError(err_msg)
-
+        random.shuffle(self.address_deque())
         self._logger.debug('Address list: {0}'.format(list(self.address_deque)))
 
     def _append(self, host, port):
@@ -210,7 +211,8 @@ class _AddressList(object):
                 return entry.data
             else:
                 # DNS resolve a single host name to multiple IP addresses
-                self.address_deque.popleft()
+                self.pop()
+                # keep host and port info for adding address entry to deque once it has been resolved
                 host, port = entry.host, entry.data
                 try:
                     resolved_hosts = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)


### PR DESCRIPTION
Associated with http://jira.verticacorp.com:8080/jira/browse/VER-78768

Simple shuffling of the address deque after the host and backup nodes have all been added. 

I believe it makes sense to do this in the constructor for a couple of reasons. 1) Randomizing in the constructor means it only needs to be done a single time. 2) Operations such as load balancing will create an expectation for the leftmost address be the host returned by the request and the following address be the originally specified host making the load balancing request.



Other Comments: 

Line 214: use of defined class operation performing same operation
Line 215: comment for algorithm clarity

Also making a note that after connection.py:227 you could simply return self.address_deque[0] instead of going through another loop iteration and logging debug info that isn't needed.