### PR TITLE
Restore DNS Round Robin Behavior

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -43,7 +43,7 @@ import ssl
 import getpass
 import uuid
 from struct import unpack
-from collections import deque, namedtuple
+from collections import deque, namedtuple, Iterable
 import random
 
 # noinspection PyCompatibility,PyUnresolvedReferences
@@ -164,7 +164,6 @@ class _AddressList(object):
                            ' must be a host string or a (host, port) tuple')
                 self._logger.error(err_msg)
                 raise TypeError(err_msg)
-        random.shuffle(self.address_deque)
         self._logger.debug('Address list: {0}'.format(list(self.address_deque)))
 
     def _append(self, host, port):
@@ -221,10 +220,11 @@ class _AddressList(object):
                     continue
 
                 # add resolved addrinfo (AF_INET and AF_INET6 only) to deque
-                for addrinfo in reversed(resolved_hosts):
-                    if addrinfo[0] in (socket.AF_INET, socket.AF_INET6):
-                        self.address_deque.appendleft(_AddressEntry(
-                            host=host, resolved=True, data=addrinfo))
+                if hasattr(resolved_hosts, '__itr__'):
+                    for addrinfo in random.shuffle(resolved_hosts):
+                        if addrinfo[0] in (socket.AF_INET, socket.AF_INET6):
+                            self.address_deque.appendleft(_AddressEntry(
+                                host=host, resolved=True, data=addrinfo))
         return None
 
     def peek_host(self):

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -43,7 +43,7 @@ import ssl
 import getpass
 import uuid
 from struct import unpack
-from collections import deque, namedtuple, Iterable
+from collections import deque, namedtuple
 import random
 
 # noinspection PyCompatibility,PyUnresolvedReferences
@@ -220,11 +220,11 @@ class _AddressList(object):
                     continue
 
                 # add resolved addrinfo (AF_INET and AF_INET6 only) to deque
-                if hasattr(resolved_hosts, '__itr__'):
-                    for addrinfo in random.shuffle(resolved_hosts):
-                        if addrinfo[0] in (socket.AF_INET, socket.AF_INET6):
-                            self.address_deque.appendleft(_AddressEntry(
-                                host=host, resolved=True, data=addrinfo))
+                random.shuffle(resolved_hosts)
+                for addrinfo in resolved_hosts:
+                    if addrinfo[0] in (socket.AF_INET, socket.AF_INET6):
+                        self.address_deque.appendleft(_AddressEntry(
+                            host=host, resolved=True, data=addrinfo))
         return None
 
     def peek_host(self):

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -164,7 +164,7 @@ class _AddressList(object):
                            ' must be a host string or a (host, port) tuple')
                 self._logger.error(err_msg)
                 raise TypeError(err_msg)
-        random.shuffle(self.address_deque())
+        random.shuffle(self.address_deque)
         self._logger.debug('Address list: {0}'.format(list(self.address_deque)))
 
     def _append(self, host, port):

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -44,6 +44,7 @@ import getpass
 import uuid
 from struct import unpack
 from collections import deque, namedtuple
+import random
 
 # noinspection PyCompatibility,PyUnresolvedReferences
 from six import raise_from, string_types, integer_types, PY2
@@ -163,7 +164,7 @@ class _AddressList(object):
                            ' must be a host string or a (host, port) tuple')
                 self._logger.error(err_msg)
                 raise TypeError(err_msg)
-
+        random.shuffle(self.address_deque())
         self._logger.debug('Address list: {0}'.format(list(self.address_deque)))
 
     def _append(self, host, port):
@@ -210,7 +211,8 @@ class _AddressList(object):
                 return entry.data
             else:
                 # DNS resolve a single host name to multiple IP addresses
-                self.address_deque.popleft()
+                self.pop()
+                # keep host and port info for adding address entry to deque once it has been resolved
                 host, port = entry.host, entry.data
                 try:
                     resolved_hosts = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)


### PR DESCRIPTION
Simple shuffling of the list of resolved hosts used to determine address information for the _AddressEntry deque. 

This is inherently difficult to test reliably. Using debug logging I could see that I had two IP addresses for localhost, being the IPv4 (127.0.0.1) and IPv6 (::1) and when logging the entry.data return from connection.py::peek() I could see that the actual address returned out of the two options was random. 

Other Comments:

Line 213: use of defined class operation performing same operation
Line 214: comment for algorithm clarity

Also making a note that after connection.py:227 you could simply return self.address_deque[0] instead of going through another loop iteration and logging debug info that isn't needed.