### PR TITLE
Limit max send message size to 8192 bytes

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -568,18 +568,13 @@ class Connection(object):
         self._logger.debug('=> %s', message)
         try:
             for data in message.fetch_message():
-                try:
-                    size = 8192 # Max msg size, consistent with how the server works
-                    pos = 0
-                    while pos < len(data):
-                        sent = vsocket.send(data[pos : pos + size])
-                        if sent == 0:
-                            raise RuntimeError("socket connection broken")
-                        pos += sent
-                except Exception:
-                    self._logger.error("couldn't send message")
-                    raise
-
+                size = 8192 # Max msg size, consistent with how the server works
+                pos = 0
+                while pos < len(data):
+                    sent = vsocket.send(data[pos : pos + size])
+                    if sent == 0:
+                        raise errors.ConnectionError("Couldn't send message: Socket connection broken")
+                    pos += sent
         except Exception as e:
             self.close_socket()
             self._logger.error(str(e))

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -569,7 +569,13 @@ class Connection(object):
         try:
             for data in message.fetch_message():
                 try:
-                    vsocket.sendall(data)
+                    size = 8192 # Max msg size, consistent with how the server works
+                    pos = 0
+                    while pos < len(data):
+                        sent = vsocket.send(data[pos : pos + size])
+                        if sent == 0:
+                            raise RuntimeError("socket connection broken")
+                        pos += sent
                 except Exception:
                     self._logger.error("couldn't send message")
                     raise


### PR DESCRIPTION
To consistent with how the server works, the message send to server should be no larger than 8192 bytes.

One known hang issue caused by this happens when:
- SSL connection is used.
- idle_session_timeout of the user's account has a value (other than default (unlimited)).
- Execute a very long query (message > 8192 bytes)