### PR TITLE
Bypass data conversion to Python objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,31 @@ with vertica_python.connect(**conn_info) as conn:
         # nCount is less than the number of rows in large_table
 ```
 
+### Bypass Data Conversion to Python object
+
+The `Cursor.disable_sqltype_converter` attribute can bypass the result data conversion to Python object.
+
+```python
+with vertica_python.connect(**conn_info) as conn:
+    cur = conn.cursor()
+    sql = "select 'foo'::VARCHAR, 100::INT, '2001-12-01 02:50:00'::TIMESTAMP"
+    
+    #### Convert SQL types to Python objects ####
+    print(cur.disable_sqltype_converter)   # Default is False
+    # False
+    cur.execute(sql)
+    print(cur.fetchall())
+    # [['foo', 100, datetime.datetime(2001, 12, 1, 2, 50)]]
+    
+    #### No Conversion: return raw bytes data ####
+    cur.disable_sqltype_converter = True   # Set attribute to True
+    cur.execute(sql)
+    print(cur.fetchall())
+    # [[b'foo', b'100', b'2001-12-01 02:50:00']]
+```
+
+As a result, this can improve query performance when you call `fetchall()` but ignore/skip result data. This can also be used when defining customized data converters.
+
 ### Shortcuts
 The `Cursor.execute()` method returns `self`. This means that you can chain a fetch operation, such as `fetchone()`, to the `execute()` call:
 ```python

--- a/README.md
+++ b/README.md
@@ -724,9 +724,9 @@ with vertica_python.connect(**conn_info) as conn:
         # nCount is less than the number of rows in large_table
 ```
 
-### Bypass Data Conversion to Python object
+### Bypass data conversion to Python objects
 
-The `Cursor.disable_sqltype_converter` attribute can bypass the result data conversion to Python object.
+The `Cursor.disable_sqltype_converter` attribute can bypass the result data conversion to Python objects.
 
 ```python
 with vertica_python.connect(**conn_info) as conn:

--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -467,6 +467,22 @@ class CursorTestCase(VerticaPythonIntegrationTestCase):
             self.assertEqual(cur.description[0].display_size, 10000)
             self.assertEqual(cur.description[1].display_size, 1000)
 
+    def test_disable_sqltype_converter(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+
+            # Default is False
+            self.assertFalse(cur.disable_sqltype_converter)
+
+            # Set with attribute setter
+            cur.disable_sqltype_converter = True
+            self.assertTrue(cur.disable_sqltype_converter)
+            cur.execute("INSERT INTO {0} (a, b) VALUES (1, 'aa')".format(self._table))
+            cur.execute("INSERT INTO {0} (a, b) VALUES (2, 'bb')".format(self._table))
+            conn.commit()
+            cur.execute("SELECT a, b FROM {0} ORDER BY a ASC".format(self._table))
+            res = cur.fetchall()
+            self.assertListOfListsEqual(res, [[b'1', b'aa'], [b'2', b'bb']])
 
 exec(CursorTestCase.createPrepStmtClass())
 

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -139,6 +139,11 @@ def date_parse(s):
 
 
 def time_parse(s):
+    """
+    Parses text representation of a TIME type.
+    :param val: bytes
+    :return: datetime.time
+    """
     s = as_str(s)
     if len(s) == 8:
         return datetime.strptime(s, '%H:%M:%S').time()


### PR DESCRIPTION
Add the `Cursor.disable_sqltype_converter` attribute to bypass data conversions from the Vertica SQL type to the native Python data type.