### PR TITLE
python client should avoid sending username as default database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ with vertica_python.connect(**conn_info) as connection:
 | port     | The port of the connection. <br>**_Default_**: 5433 |
 | user     | The database user name to use to connect to the database. <br>**_Default_**: OS login user name |
 | password | The password to use to log into the database. <br>**_Default_**: "" |
-| database | The database name. <br>**_Default_**: the value of connection option `user` |
+| database | The database name. <br>**_Default_**: "" |
 | autocommit | See [Autocommit](#autocommit). <br>**_Default_**: False |
 | backup_server_node | See [Connection Failover](#connection-failover). <br>**_Default_**: [] |
 | binary_transfer | See [Data Transfer Format](#data-transfer-format). <br>**_Default_**: False (use text format transfer) |

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -70,6 +70,7 @@ from ..vertica.log import VerticaLogging
 DEFAULT_HOST = 'localhost'
 DEFAULT_PORT = 5433
 DEFAULT_PASSWORD = ''
+DEFAULT_DATABASE = ''
 DEFAULT_AUTOCOMMIT = False
 DEFAULT_BACKUP_SERVER_NODE = []
 DEFAULT_KRB_SERVICE_NAME = 'vertica'
@@ -288,7 +289,7 @@ class Connection(object):
                 msg = 'Connection option "user" is required'
                 self._logger.error(msg)
                 raise KeyError(msg)
-        self.options.setdefault('database', self.options['user'])
+        self.options.setdefault('database', DEFAULT_DATABASE)
         self.options.setdefault('password', DEFAULT_PASSWORD)
         self.options.setdefault('autocommit', DEFAULT_AUTOCOMMIT)
         self.options.setdefault('session_label', _generate_session_label())


### PR DESCRIPTION
To accommodate the Server session layer change, now incorrect database_name will be rejected, so using empty string as default database name instead of username