### PR TITLE
#469 Support Complex type -- part 1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy-3.9']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy3.9']
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set up a Vertica server

--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -59,8 +59,8 @@ __all__ = ['Connection', 'PROTOCOL_VERSION', 'version_info', 'apilevel', 'thread
 version_info = (1, 1, 1)
 __version__ = '.'.join(map(str, version_info))
 
-# The protocol version (3.9) implemented in this library.
-PROTOCOL_VERSION = 3 << 16 | 9
+# The protocol version (3.12) implemented in this library.
+PROTOCOL_VERSION = 3 << 16 | 12
 
 apilevel = 2.0
 threadsafety = 1  # Threads may share the module, but not connections!

--- a/vertica_python/datatypes.py
+++ b/vertica_python/datatypes.py
@@ -102,6 +102,30 @@ class VerticaType(object):
     LONGVARBINARY = 116
     BINARY = 117
 
+    ROW = 300
+    ARRAY = 301 # multidimensional
+    MAP = 302
+
+    ARRAY1D_BOOL = 1505
+    ARRAY1D_INT8 = 1506
+    ARRAY1D_FLOAT8 = 1507
+    ARRAY1D_CHAR = 1508
+    ARRAY1D_VARCHAR = 1509
+    ARRAY1D_DATE = 1510
+    ARRAY1D_TIME = 1511
+    ARRAY1D_TIMESTAMP = 1512
+    ARRAY1D_TIMESTAMPTZ = 1513
+    ARRAY1D_INTERVAL = 1514
+    ARRAY1D_INTERVALYM = 1521
+    ARRAY1D_TIMETZ = 1515
+    ARRAY1D_NUMERIC = 1516
+    ARRAY1D_VARBINARY = 1517
+    ARRAY1D_UUID = 1520
+    ARRAY1D_BINARY = 1522
+    ARRAY1D_LONGVARCHAR = 1519
+    ARRAY1D_LONGVARBINARY = 1518
+
+
     def __init__(self, *values):
         self.values = values
 
@@ -159,44 +183,54 @@ INTERVAL_MASK_HOUR2MIN = INTERVAL_MASK_HOUR | INTERVAL_MASK_MINUTE
 INTERVAL_MASK_HOUR2SEC = INTERVAL_MASK_HOUR | INTERVAL_MASK_MINUTE | INTERVAL_MASK_SECOND
 INTERVAL_MASK_MIN2SEC = INTERVAL_MASK_MINUTE | INTERVAL_MASK_SECOND
 
+TYPENAME = {
+    VerticaType.UNKNOWN: "Unknown",
+    VerticaType.BOOL: "Boolean",
+    VerticaType.INT8: "Integer",
+    VerticaType.FLOAT8: "Float",
+    VerticaType.CHAR: "Char",
+    VerticaType.VARCHAR: "Varchar",
+    VerticaType.LONGVARCHAR: "Long Varchar",
+    VerticaType.DATE: "Date",
+    VerticaType.TIME: "Time",
+    VerticaType.TIMETZ: "TimeTz",
+    VerticaType.TIMESTAMP: "Timestamp",
+    VerticaType.TIMESTAMPTZ: "TimestampTz",
+    VerticaType.BINARY: "Binary",
+    VerticaType.VARBINARY: "Varbinary",
+    VerticaType.LONGVARBINARY: "Long Varbinary",
+    VerticaType.NUMERIC: "Numeric",
+    VerticaType.UUID: "Uuid",
+    VerticaType.ROW: "Row",
+    VerticaType.ARRAY: "Array",
+    VerticaType.MAP: "Map",
+    VerticaType.ARRAY1D_BOOL: "Array[Boolean]",
+    VerticaType.ARRAY1D_INT8: "Array[Int8]",
+    VerticaType.ARRAY1D_FLOAT8: "Array[Float8]",
+    VerticaType.ARRAY1D_CHAR: "Array[Char]",
+    VerticaType.ARRAY1D_VARCHAR: "Array[Varchar]",
+    VerticaType.ARRAY1D_DATE: "Array[Date]",
+    VerticaType.ARRAY1D_TIME: "Array[Time]",
+    VerticaType.ARRAY1D_TIMESTAMP: "Array[Timestamp]",
+    VerticaType.ARRAY1D_TIMESTAMPTZ: "Array[TimestampTz]",
+    VerticaType.ARRAY1D_TIMETZ: "Array[TimeTz]",
+    VerticaType.ARRAY1D_NUMERIC: "Array[Numeric]",
+    VerticaType.ARRAY1D_VARBINARY: "Array[Varbinary]",
+    VerticaType.ARRAY1D_UUID: "Array[Uuid]",
+    VerticaType.ARRAY1D_BINARY: "Array[Binary]",
+    VerticaType.ARRAY1D_LONGVARCHAR: "Array[Long Varchar]",
+    VerticaType.ARRAY1D_LONGVARBINARY: "Array[Long Varbinary]",
+}
 
 def getTypeName(data_type_oid, type_modifier):
     """Returns the base type name according to data_type_oid and type_modifier"""
-
-    if data_type_oid == VerticaType.BOOL:
-        return "Boolean"
-    elif data_type_oid == VerticaType.INT8:
-        return "Integer"
-    elif data_type_oid == VerticaType.FLOAT8:
-        return "Float"
-    elif data_type_oid == VerticaType.CHAR:
-        return "Char"
-    elif data_type_oid in (VerticaType.VARCHAR, VerticaType.UNKNOWN):
-        return "Varchar"
-    elif data_type_oid == VerticaType.LONGVARCHAR:
-        return "Long Varchar"
-    elif data_type_oid == VerticaType.DATE:
-        return "Date"
-    elif data_type_oid == VerticaType.TIME:
-        return "Time"
-    elif data_type_oid == VerticaType.TIMETZ:
-        return "TimeTz"
-    elif data_type_oid == VerticaType.TIMESTAMP:
-        return "Timestamp"
-    elif data_type_oid == VerticaType.TIMESTAMPTZ:
-        return "TimestampTz"
+    if data_type_oid in TYPENAME:
+        return TYPENAME[data_type_oid]
     elif data_type_oid in (VerticaType.INTERVAL, VerticaType.INTERVALYM):
         return "Interval " + getIntervalRange(data_type_oid, type_modifier)
-    elif data_type_oid == VerticaType.BINARY:
-        return "Binary"
-    elif data_type_oid == VerticaType.VARBINARY:
-        return "Varbinary"
-    elif data_type_oid == VerticaType.LONGVARBINARY:
-        return "Long Varbinary"
-    elif data_type_oid == VerticaType.NUMERIC:
-        return "Numeric"
-    elif data_type_oid == VerticaType.UUID:
-        return "Uuid"
+    elif data_type_oid in (VerticaType.ARRAY1D_INTERVAL, VerticaType.ARRAY1D_INTERVALYM):
+        # TODO
+        return "Array[Interval]"
     else:
         return "Unknown"
 

--- a/vertica_python/datatypes.py
+++ b/vertica_python/datatypes.py
@@ -106,6 +106,7 @@ class VerticaType(object):
     ARRAY = 301 # multidimensional
     MAP = 302
 
+    # one-dimensional array of a primitive type
     ARRAY1D_BOOL = 1505
     ARRAY1D_INT8 = 1506
     ARRAY1D_FLOAT8 = 1507

--- a/vertica_python/datatypes.py
+++ b/vertica_python/datatypes.py
@@ -125,6 +125,24 @@ class VerticaType(object):
     ARRAY1D_LONGVARCHAR = 1519
     ARRAY1D_LONGVARBINARY = 1518
 
+    SET_BOOL = 2705
+    SET_INT8 = 2706
+    SET_FLOAT8 = 2707
+    SET_CHAR = 2708
+    SET_VARCHAR = 2709
+    SET_DATE = 2710
+    SET_TIME = 2711
+    SET_TIMESTAMP = 2712
+    SET_TIMESTAMPTZ = 2713
+    SET_INTERVAL = 2714
+    SET_INTERVALYM = 2721
+    SET_TIMETZ = 2715
+    SET_NUMERIC = 2716
+    SET_VARBINARY = 2717
+    SET_UUID = 2720
+    SET_BINARY = 2722
+    SET_LONGVARCHAR = 2719
+    SET_LONGVARBINARY = 2718
 
     def __init__(self, *values):
         self.values = values
@@ -220,6 +238,22 @@ TYPENAME = {
     VerticaType.ARRAY1D_BINARY: "Array[Binary]",
     VerticaType.ARRAY1D_LONGVARCHAR: "Array[Long Varchar]",
     VerticaType.ARRAY1D_LONGVARBINARY: "Array[Long Varbinary]",
+    VerticaType.SET_BOOL: "Set[Boolean]",
+    VerticaType.SET_INT8: "Set[Int8]",
+    VerticaType.SET_FLOAT8: "Set[Float8]",
+    VerticaType.SET_CHAR: "Set[Char]",
+    VerticaType.SET_VARCHAR: "Set[Varchar]",
+    VerticaType.SET_DATE: "Set[Date]",
+    VerticaType.SET_TIME: "Set[Time]",
+    VerticaType.SET_TIMESTAMP: "Set[Timestamp]",
+    VerticaType.SET_TIMESTAMPTZ: "Set[TimestampTz]",
+    VerticaType.SET_TIMETZ: "Set[TimeTz]",
+    VerticaType.SET_NUMERIC: "Set[Numeric]",
+    VerticaType.SET_VARBINARY: "Set[Varbinary]",
+    VerticaType.SET_UUID: "Set[Uuid]",
+    VerticaType.SET_BINARY: "Set[Binary]",
+    VerticaType.SET_LONGVARCHAR: "Set[Long Varchar]",
+    VerticaType.SET_LONGVARBINARY: "Set[Long Varbinary]",
 }
 
 def getTypeName(data_type_oid, type_modifier):
@@ -229,8 +263,11 @@ def getTypeName(data_type_oid, type_modifier):
     elif data_type_oid in (VerticaType.INTERVAL, VerticaType.INTERVALYM):
         return "Interval " + getIntervalRange(data_type_oid, type_modifier)
     elif data_type_oid in (VerticaType.ARRAY1D_INTERVAL, VerticaType.ARRAY1D_INTERVALYM):
-        # TODO
+        # TODO IntervalRange
         return "Array[Interval]"
+    elif data_type_oid in (VerticaType.SET_INTERVAL, VerticaType.SET_INTERVALYM):
+        # TODO IntervalRange
+        return "Set[Interval]"
     else:
         return "Unknown"
 

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -70,8 +70,16 @@ class Column(object):
         self.null_ok = col['null_ok']
         self.is_identity = col['is_identity']
         self.format_code = col['format_code']
+        self.child_columns = []
         self.props = ColumnTuple(self.name, self.type_code, self.display_size, self.internal_size,
                                  self.precision, self.scale, self.null_ok)
+
+    def add_child_column(self, col):
+        """
+        Complex types involve multiple columns arranged in a hierarchy of parents and children.
+        Each parent column stores references to child columns in a list.
+        """
+        self.child_columns.append(col)
 
     def __str__(self):
         return as_str(str(self.props))

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -328,8 +328,8 @@ class Connection(object):
         self.startup_connection()
 
         # Complex types metadata is returned since protocol version 3.12
-        self.complex_types_enabled = self.parameters.get('request_complex_types', 'off') == 'on' and \
-                                     self.parameters['protocol_version'] >= (3 << 16 | 12)
+        self.complex_types_enabled = self.parameters['protocol_version'] >= (3 << 16 | 12) and \
+                                     self.parameters.get('request_complex_types', 'off') == 'on'
         self._logger.info('Connection is ready')
 
     #############################################

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -306,7 +306,7 @@ class Cursor(object):
                 self._message = self.connection.read_message()
                 return row
             elif isinstance(self._message, messages.RowDescription):
-                self.description = [Column(fd) for fd in self._message.fields]
+                self.description = self._message.get_description()
                 self._deserializers = self._des.get_row_deserializers(self.description,
                                         {'unicode_error': self.unicode_error,
                                          'session_tz': self.connection.parameters.get('timezone', 'unknown')})
@@ -366,7 +366,7 @@ class Cursor(object):
             # there might be another set, read next message to find out
             self._message = self.connection.read_message()
             if isinstance(self._message, messages.RowDescription):
-                self.description = [Column(fd) for fd in self._message.fields]
+                self.description = self._message.get_description()
                 self._deserializers = self._des.get_row_deserializers(self.description,
                                         {'unicode_error': self.unicode_error,
                                          'session_tz': self.connection.parameters.get('timezone', 'unknown')})
@@ -657,7 +657,7 @@ class Cursor(object):
         if isinstance(self._message, messages.ErrorResponse):
             raise errors.QueryError.from_error_response(self._message, query)
         elif isinstance(self._message, messages.RowDescription):
-            self.description = [Column(fd) for fd in self._message.fields]
+            self.description = self._message.get_description()
             self._deserializers = self._des.get_row_deserializers(self.description,
                                     {'unicode_error': self.unicode_error,
                                      'session_tz': self.connection.parameters.get('timezone', 'unknown')})
@@ -850,7 +850,7 @@ class Cursor(object):
         if isinstance(self._message, messages.NoData):
             self.description = None  # response was NoData for a DDL/transaction PreparedStatement
         else:
-            self.description = [Column(fd) for fd in self._message.fields]
+            self.description = self._message.get_description()
             self._deserializers = self._des.get_row_deserializers(self.description,
                                     {'unicode_error': self.unicode_error,
                                      'session_tz': self.connection.parameters.get('timezone', 'unknown')})

--- a/vertica_python/vertica/messages/frontend_messages/startup.py
+++ b/vertica_python/vertica/messages/frontend_messages/startup.py
@@ -81,6 +81,7 @@ class Startup(BulkFrontendMessage):
             b'client_pid': pid,
             b'autocommit': 'on' if autocommit else 'off',
             b'binary_data_protocol': '1' if binary_transfer else '0', # Defaults to text format '0'
+            b'protocol_features': '{"request_complex_types":true}',
         }
 
     def read_bytes(self):

--- a/vertica_python/vertica/messages/message.py
+++ b/vertica_python/vertica/messages/message.py
@@ -96,10 +96,10 @@ class BackendMessage(Message):
     _message_id_map = {}
 
     @classmethod
-    def from_type(cls, type_, data):
+    def from_type(cls, type_, data, **kwargs):
         klass = cls._message_id_map.get(type_)
         if klass is not None:
-            return klass(data)
+            return klass(data, **kwargs)
         else:
             from .backend_messages import Unknown
             return Unknown(type_, data)


### PR DESCRIPTION
Partial fix for #469.

Server since v12.0.2 will send complex types (ARRAY, ROW, MAP, SET) OIDs to the client, which can be retrieved by the ' type_code' of `Cursor.description`. `Cursor.description` is a list of Column objects, there is a new Column.child_columns that returns a list of child Column objects for nested complex types (e.g. ARRAY[ARRAY[INT]], ROW(NUMERIC, ARRAY[VARCHAR])). This type hierarchy will be used to parse complex types data.