### PR TITLE
#469 Support Complex type -- part 2

### DIFF
--- a/vertica_python/datatypes.py
+++ b/vertica_python/datatypes.py
@@ -257,6 +257,27 @@ TYPENAME = {
     VerticaType.SET_LONGVARBINARY: "Set[Long Varbinary]",
 }
 
+COMPLEX_ELEMENT_TYPE = {
+    VerticaType.ARRAY1D_BOOL: VerticaType.BOOL,
+    VerticaType.ARRAY1D_INT8: VerticaType.INT8,
+    VerticaType.ARRAY1D_FLOAT8: VerticaType.FLOAT8,
+    VerticaType.ARRAY1D_CHAR: VerticaType.CHAR,
+    VerticaType.ARRAY1D_VARCHAR: VerticaType.VARCHAR,
+    VerticaType.ARRAY1D_DATE: VerticaType.DATE,
+    VerticaType.ARRAY1D_TIME: VerticaType.TIME,
+    VerticaType.ARRAY1D_TIMESTAMP: VerticaType.TIMESTAMP,
+    VerticaType.ARRAY1D_TIMESTAMPTZ: VerticaType.TIMESTAMPTZ,
+    VerticaType.ARRAY1D_TIMETZ: VerticaType.TIMETZ,
+    VerticaType.ARRAY1D_INTERVAL: VerticaType.INTERVAL,
+    VerticaType.ARRAY1D_INTERVALYM: VerticaType.INTERVALYM,
+    VerticaType.ARRAY1D_NUMERIC: VerticaType.NUMERIC,
+    VerticaType.ARRAY1D_VARBINARY: VerticaType.VARBINARY,
+    VerticaType.ARRAY1D_UUID: VerticaType.UUID,
+    VerticaType.ARRAY1D_BINARY: VerticaType.BINARY,
+    VerticaType.ARRAY1D_LONGVARCHAR: VerticaType.LONGVARCHAR,
+    VerticaType.ARRAY1D_LONGVARBINARY: VerticaType.LONGVARBINARY,
+}
+
 def getTypeName(data_type_oid, type_modifier):
     """Returns the base type name according to data_type_oid and type_modifier"""
     if data_type_oid in TYPENAME:
@@ -272,6 +293,8 @@ def getTypeName(data_type_oid, type_modifier):
     else:
         return "Unknown"
 
+def getComplexElementType(data_type_oid):
+    return COMPLEX_ELEMENT_TYPE.get(data_type_oid)
 
 def getIntervalRange(data_type_oid, type_modifier):
     """Extracts an interval's range from the bits set in its type_modifier"""

--- a/vertica_python/vertica/deserializer.py
+++ b/vertica_python/vertica/deserializer.py
@@ -27,7 +27,7 @@ if PY2:
     from binascii import hexlify
 
 from .. import errors
-from ..compat import as_str
+from ..compat import as_str, as_bytes
 from ..datatypes import VerticaType
 from ..vertica.column import FormatCode
 
@@ -446,6 +446,7 @@ def load_varbinary_text(s, ctx):
     :param ctx: dict
     :return: bytes
     """
+    s = as_bytes(s)
     buf = []
     i = 0
     while i < len(s):
@@ -473,6 +474,49 @@ def load_json_text(val, ctx):
     """
     return json.loads(val.decode('utf-8', ctx['unicode_error']))
 
+def load_array_text(val, ctx):
+    val = val.decode('utf-8', ctx['unicode_error'])
+    # Some old servers have a bug of sending ARRAY oid without child metadata
+    if len(ctx['column'].child_columns) == 0:
+        return val
+
+    json_data = json.loads(val)
+    if not isinstance(json_data, list):
+        raise TypeError('Expected a list, got {}'.format(json_data))
+    return parse_array(json_data, ctx)
+
+def parse_array(json_data, ctx):
+    # An array has only one child, all elements in the array are the same type.
+    child_ctx = ctx.copy()
+    child_ctx['column'] = ctx['column'].child_columns[0]
+    parsed_array = [None] * len(json_data)
+    for idx, element in enumerate(json_data):
+        if element is None:
+            continue
+        parsed_array[idx] = parse_json_element(element, child_ctx)
+    return parsed_array
+
+def parse_json_element(element, ctx):
+    type_code = ctx['column'].type_code
+    if type_code in (VerticaType.BOOL, VerticaType.INT8, VerticaType.FLOAT8,
+                     VerticaType.CHAR, VerticaType.VARCHAR, VerticaType.LONGVARCHAR):
+        return element
+    # element type: (PY2) unicode / (PY3) str
+    if type_code in (VerticaType.DATE, VerticaType.TIME, VerticaType.TIMETZ,
+                     VerticaType.TIMESTAMP, VerticaType.TIMESTAMPTZ,
+                     VerticaType.INTERVAL, VerticaType.INTERVALYM,
+                     VerticaType.BINARY, VerticaType.VARBINARY,
+                     VerticaType.LONGVARBINARY):
+        return DEFAULTS[FormatCode.TEXT][type_code](element, ctx)
+    elif type_code == VerticaType.NUMERIC:
+        return Decimal(element)
+    elif type_code == VerticaType.UUID:
+        return UUID(element)
+    # element type: list
+    elif type_code == VerticaType.ARRAY:
+        return parse_array(element, ctx)
+    return element
+
 DEFAULTS = {
     FormatCode.TEXT: {
         VerticaType.UNKNOWN: None,
@@ -494,12 +538,25 @@ DEFAULTS = {
         VerticaType.BINARY: load_varbinary_text,
         VerticaType.VARBINARY: load_varbinary_text,
         VerticaType.LONGVARBINARY: load_varbinary_text,
+        VerticaType.ARRAY: load_array_text,
         VerticaType.ARRAY1D_BOOL: load_json_text,
         VerticaType.ARRAY1D_INT8: load_json_text,
         VerticaType.ARRAY1D_FLOAT8: load_json_text,
+        VerticaType.ARRAY1D_NUMERIC: load_array_text,
         VerticaType.ARRAY1D_CHAR: load_json_text,
         VerticaType.ARRAY1D_VARCHAR: load_json_text,
         VerticaType.ARRAY1D_LONGVARCHAR: load_json_text,
+        VerticaType.ARRAY1D_DATE: load_array_text,
+        VerticaType.ARRAY1D_TIME: load_array_text,
+        VerticaType.ARRAY1D_TIMETZ: load_array_text,
+        VerticaType.ARRAY1D_TIMESTAMP: load_array_text,
+        VerticaType.ARRAY1D_TIMESTAMPTZ: load_array_text,
+        VerticaType.ARRAY1D_INTERVAL: load_array_text,
+        VerticaType.ARRAY1D_INTERVALYM: load_array_text,
+        VerticaType.ARRAY1D_UUID: load_array_text,
+        VerticaType.ARRAY1D_BINARY: load_array_text,
+        VerticaType.ARRAY1D_VARBINARY: load_array_text,
+        VerticaType.ARRAY1D_LONGVARBINARY: load_array_text,
     },
     FormatCode.BINARY: {
         VerticaType.UNKNOWN: None,
@@ -521,12 +578,25 @@ DEFAULTS = {
         VerticaType.BINARY: None,
         VerticaType.VARBINARY: None,
         VerticaType.LONGVARBINARY: None,
+        VerticaType.ARRAY: load_array_text,
         VerticaType.ARRAY1D_BOOL: load_json_text,
         VerticaType.ARRAY1D_INT8: load_json_text,
         VerticaType.ARRAY1D_FLOAT8: load_json_text,
+        VerticaType.ARRAY1D_NUMERIC: load_array_text,
         VerticaType.ARRAY1D_CHAR: load_json_text,
         VerticaType.ARRAY1D_VARCHAR: load_json_text,
         VerticaType.ARRAY1D_LONGVARCHAR: load_json_text,
+        VerticaType.ARRAY1D_DATE: load_array_text,
+        VerticaType.ARRAY1D_TIME: load_array_text,
+        VerticaType.ARRAY1D_TIMETZ: load_array_text,
+        VerticaType.ARRAY1D_TIMESTAMP: load_array_text,
+        VerticaType.ARRAY1D_TIMESTAMPTZ: load_array_text,
+        VerticaType.ARRAY1D_INTERVAL: load_array_text,
+        VerticaType.ARRAY1D_INTERVALYM: load_array_text,
+        VerticaType.ARRAY1D_UUID: load_array_text,
+        VerticaType.ARRAY1D_BINARY: load_array_text,
+        VerticaType.ARRAY1D_VARBINARY: load_array_text,
+        VerticaType.ARRAY1D_LONGVARBINARY: load_array_text,
     },
 }
 

--- a/vertica_python/vertica/deserializer.py
+++ b/vertica_python/vertica/deserializer.py
@@ -14,6 +14,7 @@
 
 from __future__ import print_function, division, absolute_import
 
+import json
 import re
 from datetime import date, datetime, time, timedelta
 from dateutil import tz
@@ -463,6 +464,14 @@ def load_varbinary_text(s, ctx):
         buf.append(c)
     return b''.join(buf)
 
+def load_json_text(val, ctx):
+    """
+    Parses text/binary representation of a complex type with default JSONDecoder.
+    :param val: bytes
+    :param ctx: dict
+    :return: list or dict
+    """
+    return json.loads(val.decode('utf-8', ctx['unicode_error']))
 
 DEFAULTS = {
     FormatCode.TEXT: {
@@ -485,6 +494,12 @@ DEFAULTS = {
         VerticaType.BINARY: load_varbinary_text,
         VerticaType.VARBINARY: load_varbinary_text,
         VerticaType.LONGVARBINARY: load_varbinary_text,
+        VerticaType.ARRAY1D_BOOL: load_json_text,
+        VerticaType.ARRAY1D_INT8: load_json_text,
+        VerticaType.ARRAY1D_FLOAT8: load_json_text,
+        VerticaType.ARRAY1D_CHAR: load_json_text,
+        VerticaType.ARRAY1D_VARCHAR: load_json_text,
+        VerticaType.ARRAY1D_LONGVARCHAR: load_json_text,
     },
     FormatCode.BINARY: {
         VerticaType.UNKNOWN: None,
@@ -506,6 +521,12 @@ DEFAULTS = {
         VerticaType.BINARY: None,
         VerticaType.VARBINARY: None,
         VerticaType.LONGVARBINARY: None,
+        VerticaType.ARRAY1D_BOOL: load_json_text,
+        VerticaType.ARRAY1D_INT8: load_json_text,
+        VerticaType.ARRAY1D_FLOAT8: load_json_text,
+        VerticaType.ARRAY1D_CHAR: load_json_text,
+        VerticaType.ARRAY1D_VARCHAR: load_json_text,
+        VerticaType.ARRAY1D_LONGVARCHAR: load_json_text,
     },
 }
 


### PR DESCRIPTION
Partial fix for #469.

Parse ARRAY type data into a _list_. The scope of this PR:
- Support: one-dimensional or multi-dimensional arrays. E.g. Numeric data in an array will be converted to [decimal.Decimal](https://docs.python.org/3/library/decimal.html#decimal.Decimal) objects.
- Not Support: arrays that contain structs ([ROW](https://www.vertica.com/docs/12.0.x/HTML/Content/Authoring/SQLReferenceManual/DataTypes/ROW.htm)s), i.e. structs in an array will be parsed by `json.loads()`, some elements remain as strings.