### PR TITLE
#469 Support Complex type -- part 4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', 'pypy3.9']
+        python-version: ['2.7', '3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.9']
 
     steps:
       - name: Check out repository
@@ -22,7 +22,7 @@ jobs:
         run: |
           docker run -d -p 5433:5433 -p 5444:5444 \
             --name vertica_docker \
-            vertica/vertica-ce:12.0.2-0
+            vertica/vertica-ce:12.0.1-0
           echo "Vertica startup ..."
           until docker exec vertica_docker test -f /data/vertica/VMart/agent_start.out; do \
             echo "..."; \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         run: |
           docker run -d -p 5433:5433 -p 5444:5444 \
             --name vertica_docker \
-            vertica/vertica-ce:12.0.1-0
+            vertica/vertica-ce:12.0.2-0
           echo "Vertica startup ..."
           until docker exec vertica_docker test -f /data/vertica/VMart/agent_start.out; do \
             echo "..."; \

--- a/README.md
+++ b/README.md
@@ -804,12 +804,16 @@ When a query is executed and `Cursor.fetch*()` is called, SQL data (bytes) are d
 | TIMESTAMP      | datetime.datetime<sup>[1]</sup> |
 | TIMESTAMPTZ    | datetime.datetime<sup>[1]</sup> |
 | INTERVAL	     | [dateutil.relativedelta.relativedelta](https://dateutil.readthedocs.io/en/stable/relativedelta.html#dateutil.relativedelta.relativedelta) |
-| ARRAY          | list               |
-| SET            | set                |
+| ARRAY          | list<sup>[3]</sup> |
+| SET            | set<sup>[3]</sup>  |
+| ROW            | dict<sup>[3]</sup> |
+| MAP            | dict<sup>[3]</sup> |
 
 <sup>[1]</sup>Python’s datetime.date and datetime.datetime only supports date ranges 0001-01-01 to 9999-12-31. Retrieving a value of BC date or future date (year>9999) results in an error.
 
 <sup>[2]</sup>Python’s datetime.time only supports times until 23:59:59. Retrieving a value of 24:00:00 results in an error.
+
+<sup>[3]</sup>Server before v12.0.2 cannot provide enough metadata for complex types, so the client will convert data to _str_ instead.
 
 
 #### Bypass data conversion to Python objects

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Please check out [release notes](https://github.com/vertica/vertica-python/releases) to learn about the latest improvements.
 
-vertica-python has been tested with Vertica 12.0.1 and Python 2.7/3.7/3.8/3.9/3.10. Feel free to submit issues and/or pull requests (Read up on our [contributing guidelines](#contributing-guidelines)).
+vertica-python has been tested with Vertica 12.0.2 and Python 2.7/3.7/3.8/3.9/3.10. Feel free to submit issues and/or pull requests (Read up on our [contributing guidelines](#contributing-guidelines)).
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ with vertica_python.connect(**conn_info) as connection:
 | unicode_error | See [UTF-8 encoding issues](#utf-8-encoding-issues). <br>**_Default_**: 'strict' (throw error on invalid UTF-8 results) |
 | use_prepared_statements | See [Passing parameters to SQL queries](#passing-parameters-to-sql-queries). <br>**_Default_**: False |
 | dsn | See [Set Properties with Connection String](#set-properties-with-connection-string). |
-
+| request_complex_types | See [SQL Data conversion to Python objects](#sql-data-conversion-to-python-objects). <br>**_Default_**: True |
 
 
 Below are a few important connection topics you may deal with, or you can skip and jump to the next section: [Send Queries and Retrieve Results](#send-queries-and-retrieve-results)
@@ -813,7 +813,7 @@ When a query is executed and `Cursor.fetch*()` is called, SQL data (bytes) are d
 
 <sup>[2]</sup>Python’s datetime.time only supports times until 23:59:59. Retrieving a value of 24:00:00 results in an error.
 
-<sup>[3]</sup>Server before v12.0.2 cannot provide enough metadata for complex types, so the client will convert data to _str_ instead.
+<sup>[3]</sup>If connection option 'request_complex_types' set to _False_, the server returns all complex types as VARCHAR/LONG VARCHAR Json strings, so the client will convert data to _str_ instead. Server before v12.0.2 cannot provide enough metadata for complex types, the behavior is equal to request_complex_types=False.
 
 
 #### Bypass data conversion to Python objects

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Please check out [release notes](https://github.com/vertica/vertica-python/releases) to learn about the latest improvements.
 
-vertica-python has been tested with Vertica 12.0.2 and Python 2.7/3.7/3.8/3.9/3.10. Feel free to submit issues and/or pull requests (Read up on our [contributing guidelines](#contributing-guidelines)).
+vertica-python has been tested with Vertica 12.0.2 and Python 2.7/3.7/3.8/3.9/3.10/3.11. Feel free to submit issues and/or pull requests (Read up on our [contributing guidelines](#contributing-guidelines)).
 
 
 ## Installation

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Database",
         "Topic :: Database :: Database Engines/Servers",
         "Topic :: Database :: Front-Ends",

--- a/vertica_python/datatypes.py
+++ b/vertica_python/datatypes.py
@@ -304,11 +304,9 @@ def getTypeName(data_type_oid, type_modifier):
     elif data_type_oid in (VerticaType.INTERVAL, VerticaType.INTERVALYM):
         return "Interval " + getIntervalRange(data_type_oid, type_modifier)
     elif data_type_oid in (VerticaType.ARRAY1D_INTERVAL, VerticaType.ARRAY1D_INTERVALYM):
-        # TODO IntervalRange
-        return "Array[Interval]"
+        return "Array[Interval {}]".format(getIntervalRange(COMPLEX_ELEMENT_TYPE[data_type_oid], type_modifier))
     elif data_type_oid in (VerticaType.SET_INTERVAL, VerticaType.SET_INTERVALYM):
-        # TODO IntervalRange
-        return "Set[Interval]"
+        return "Set[Interval {}]".format(getIntervalRange(COMPLEX_ELEMENT_TYPE[data_type_oid], type_modifier))
     else:
         return "Unknown"
 

--- a/vertica_python/tests/integration_tests/test_datatypes.py
+++ b/vertica_python/tests/integration_tests/test_datatypes.py
@@ -79,6 +79,16 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         super(ComplexTypeTestCase, self).setUp()
         self.require_protocol_at_least(3 << 16 | 12)
 
+    ######################################################
+    # tests for connection option 'request_complex_types'
+    ######################################################
+    def test_connection_option(self):
+        self._conn_info['request_complex_types'] = False
+        with self._connect() as conn:
+            cur = conn.cursor()
+            res = self._query_and_fetchone("SELECT ARRAY[-500, 0, null, 500]::ARRAY[INT]")
+            self.assertEqual(res[0], '[-500,0,null,500]')
+
     #######################
     # tests for ARRAY type
     #######################

--- a/vertica_python/tests/integration_tests/test_datatypes.py
+++ b/vertica_python/tests/integration_tests/test_datatypes.py
@@ -271,6 +271,11 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         self.assertEqual(res[1], [])
         self.assertEqual(res[2], None)
 
+    def test_Array_dummy_type(self):
+        query = "SELECT ARRAY[]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [])
+
     def test_NDArray_type(self):
         query = "SELECT ARRAY[ARRAY[1,2],ARRAY[3,4],null,ARRAY[5,null],ARRAY[]]::ARRAY[ARRAY[INT]], ARRAY[]::ARRAY[ARRAY[INT]], null::ARRAY[ARRAY[INT]]"
         res = self._query_and_fetchone(query)
@@ -289,7 +294,7 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         query = "SELECT ROW(null, 'Amy', -3::int, '-Infinity'::float, 2.5::numeric, '2021-10-23'::DATE, false::bool), ROW(), null::ROW(a VARCHAR)"
         res = self._query_and_fetchone(query)
         self.assertEqual(res[0], {"f0":None,"f1":"Amy","f2":-3,"f3":float('-Inf'),"f4":Decimal('2.5'),"f5":date(2021, 10, 23),"f6":False})
-        self.assertEqual(res[1], '{}') # TODO
+        self.assertEqual(res[1], {})
         self.assertEqual(res[2], None)
 
     def test_NDRow_type(self):

--- a/vertica_python/tests/integration_tests/test_datatypes.py
+++ b/vertica_python/tests/integration_tests/test_datatypes.py
@@ -79,6 +79,9 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         super(ComplexTypeTestCase, self).setUp()
         self.require_protocol_at_least(3 << 16 | 12)
 
+    #######################
+    # tests for ARRAY type
+    #######################
     def test_1DArray_boolean_type(self):
         query = "SELECT ARRAY['t', 'f', null]::ARRAY[BOOL], ARRAY[]::ARRAY[BOOL], null::ARRAY[BOOL]"
         res = self._query_and_fetchone(query)
@@ -226,10 +229,10 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
 
         query = "SELECT ARRAY['216901.024', '216901', null]::ARRAY[INTERVAL SECOND], ARRAY[]::ARRAY[INTERVAL SECOND], null::ARRAY[INTERVAL SECOND]"
         res = self._query_and_fetchone(query)
-        self.assertEqual(res[0], [relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1, microseconds=+24000), relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1), None])
+        self.assertEqual(res[0], [relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1, microseconds=+24000),
+                                  relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1), None])
         self.assertEqual(res[1], [])
         self.assertEqual(res[2], None)
-
 
     def test_1DArray_intervalYM_type(self):
         query = "SELECT ARRAY['1y 10m', '1y', '10m ago', null]::ARRAY[INTERVAL YEAR TO MONTH], ARRAY[]::ARRAY[INTERVAL YEAR TO MONTH], null::ARRAY[INTERVAL YEAR TO MONTH]"
@@ -293,16 +296,170 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
 
         query = "SELECT ARRAY[ARRAY[0.0,0.1,0.2],ARRAY[-1.0,-1.1,-1.2],ARRAY['Infinity'::float, '-Infinity'::float, null, 1.23456e-18]]::ARRAY[ARRAY[FLOAT]]"
         res = self._query_and_fetchone(query)
-        self.assertEqual(res[0], [[0.0,0.1,0.2],[-1.0,-1.1,-1.2],[float('Inf'), float('-Inf'), None, 1.23456e-18]])
+        self.assertEqual(res[0], [[0.0,0.1,0.2], [-1.0,-1.1,-1.2], [float('Inf'), float('-Inf'), None, 1.23456e-18]])
 
-    def test_Set_integer_type(self):
+    def test_Array_with_Row_type(self):
+        query = "SELECT ARRAY[ROW('Amy' AS name, 2 AS id, '2021-06-10'::DATE AS date),ROW('Fred' AS first_name, 4 AS id, '1998-02-24'::DATE)]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [{"first_name":"Amy","id":2,"date":date(2021, 6, 10)},{"first_name":"Fred","id":4,"date":date(1998, 2, 24)}])
+
+
+    #####################
+    # tests for SET type
+    #####################
+    def test_1DSet_boolean_type(self):
+        query = "SELECT SET['t', 'f', null]::SET[BOOL], SET[]::SET[BOOL], null::SET[BOOL]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {True, False, None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_integer_type(self):
         query = "SELECT SET[0,1,-2,3,null]::SET[INT], SET[]::SET[INT], null::SET[INT]"
         res = self._query_and_fetchone(query)
         self.assertEqual(res[0], {0, 1, -2, 3, None})
         self.assertEqual(res[1], set())
         self.assertEqual(res[2], None)
 
-    def test_Set_intervalYM_type(self):
+    def test_1DSet_float_type(self):
+        query = ("SELECT SET['Infinity'::float, '-Infinity'::float, null, -1.234, 0, 1.23456e-18]::SET[FLOAT],"
+                 " SET[]::SET[FLOAT], null::SET[FLOAT]")
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {float('Inf'), float('-Inf'), None, -1.234, 0.0, 1.23456e-18})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_numeric_type(self):
+        query = "SELECT SET[-1.12, 0, null, 1234567890123456789.0123456789]::SET[NUMERIC], SET[]::SET[DECIMAL], null::SET[NUMERIC]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {Decimal('-1.1200000000'), Decimal('0E-10'), None, Decimal('1234567890123456789.0123456789')})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_char_type(self):
+        query = u"SELECT SET['a', '\u16b1b', null, 'foo']::SET[CHAR(3)], SET[]::SET[CHAR(4)], null::SET[CHAR(5)]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {'a  ', u'\u16b1', None, 'foo'})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_varchar_type(self):
+        query = u"SELECT SET['', '\u16b1\nb', null, 'foo']::SET[VARCHAR(10),4], SET[]::SET[VARCHAR(4)], null::SET[VARCHAR]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {'', u'\u16b1\nb', None, 'foo'})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_date_type(self):
+        query = "SELECT SET['2021-06-10', null, '0221-05-02']::SET[DATE], SET[]::SET[DATE], null::SET[DATE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {date(2021, 6, 10), None, date(221, 5, 2)})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_time_type(self):
+        query = "SELECT SET['00:00:00.00', null, '22:36:33.123956']::SET[TIME(3)], SET[]::SET[TIME(4)], null::SET[TIME]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {time(0, 0, 0), None, time(22, 36, 33, 124000)})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_timetz_type(self):
+        query = "SELECT SET['22:36:33.12345+0630', null, '800-02-03 22:36:33.123456 America/Cayman']::SET[TIMETZ(3)], SET[]::SET[TIMETZ(4)], null::SET[TIMETZ]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {time(22, 36, 33, 123000, tzinfo=tzoffset(None, 23400)), None, 
+                                  time(22, 36, 33, 123000, tzinfo=tzoffset(None, -19176))})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_timestamp_type(self):
+        query = "SELECT SET['276-12-1 11:22:33', '2001-12-01 00:30:45.087', null]::SET[TIMESTAMP], SET[]::SET[TIMESTAMP(4)], null::SET[TIMESTAMP]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {datetime(276, 12, 1, 11, 22, 33), datetime(2001, 12, 1, 0, 30, 45, 87000), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_timestamptz_type(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SET TIMEZONE 'America/Cayman'") # set session's time zone
+            cur.fetchall()
+            query = "SELECT SET['276-12-1 11:22:33+0630', '2001-12-01 00:30:45.087 America/Cayman', null]::SET[TIMESTAMPTZ], SET[]::SET[TIMESTAMPTZ(4)], null::SET[TIMESTAMPTZ]"
+            cur.execute(query)
+            res = cur.fetchone()
+            self.assertEqual(res[0], {datetime(276, 11, 30, 23, 32, 57, tzinfo=tzoffset(None, -19176)),
+                                datetime(2001, 12, 1, 0, 30, 45, 87000, tzinfo=tzoffset(None, -18000)), None})
+            self.assertEqual(res[1], set())
+            self.assertEqual(res[2], None)
+
+    def test_1DSet_interval_type(self):
+        query = "SELECT SET['1 02:03:04.0005', '1 02:03:04', '02:03:04.0005', '02:03', null]::SET[INTERVAL DAY TO SECOND], SET[]::SET[INTERVAL DAY TO SECOND], null::SET[INTERVAL DAY TO SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(days=+1, hours=+2, minutes=+3, seconds=+4, microseconds=+500),
+                relativedelta(days=+1, hours=+2, minutes=+3, seconds=+4),
+                relativedelta(hours=+2, minutes=+3, seconds=+4, microseconds=+500),
+                relativedelta(hours=+2, minutes=+3), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['1 02:03', '02:03', null]::SET[INTERVAL DAY TO MINUTE], SET[]::SET[INTERVAL DAY TO MINUTE], null::SET[INTERVAL DAY TO MINUTE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(days=+1, hours=+2, minutes=+3), relativedelta(hours=+2, minutes=+3), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['1 02:03', '6', '02:03', null]::SET[INTERVAL DAY TO HOUR], SET[]::SET[INTERVAL DAY TO HOUR], null::SET[INTERVAL DAY TO HOUR]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(days=+1, hours=+2), relativedelta(days=+6), relativedelta(hours=+2), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['123', '-6', null]::SET[INTERVAL DAY], SET[]::SET[INTERVAL DAY], null::SET[INTERVAL DAY]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(days=+123), relativedelta(days=-6), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['02:03:04', '02:03:04.0005', '02:03', null]::SET[INTERVAL HOUR TO SECOND], SET[]::SET[INTERVAL HOUR TO SECOND], null::SET[INTERVAL HOUR TO SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(hours=+2, minutes=+3, seconds=+4),
+                relativedelta(hours=+2, minutes=+3, seconds=+4, microseconds=+500),
+                relativedelta(hours=+2, minutes=+3), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['02:03:04', '-02:03', null]::SET[INTERVAL HOUR TO MINUTE], SET[]::SET[INTERVAL HOUR TO MINUTE], null::SET[INTERVAL HOUR TO MINUTE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(hours=+2, minutes=+3), relativedelta(hours=-2, minutes=-3), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['32', '-03', null]::SET[INTERVAL HOUR], SET[]::SET[INTERVAL HOUR], null::SET[INTERVAL HOUR]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(days=+1, hours=+8), relativedelta(hours=-3), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['00:04.0005', '03:04', null]::SET[INTERVAL MINUTE TO SECOND], SET[]::SET[INTERVAL MINUTE TO SECOND], null::SET[INTERVAL MINUTE TO SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(seconds=+4, microseconds=+500), relativedelta(minutes=+3, seconds=+4), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['03', '-34', null]::SET[INTERVAL MINUTE], SET[]::SET[INTERVAL MINUTE], null::SET[INTERVAL MINUTE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(minutes=+3), relativedelta(minutes=-34), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+        query = "SELECT SET['216901.024', '216901', null]::SET[INTERVAL SECOND], SET[]::SET[INTERVAL SECOND], null::SET[INTERVAL SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1, microseconds=+24000),
+                                  relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_intervalYM_type(self):
         query = "SELECT SET['1y 10m', '1y', '10m ago', null]::SET[INTERVAL YEAR TO MONTH], SET[]::SET[INTERVAL YEAR TO MONTH], null::SET[INTERVAL YEAR TO MONTH]"
         res = self._query_and_fetchone(query)
         self.assertEqual(res[0], {relativedelta(years=+1, months=+10), relativedelta(years=+1), relativedelta(months=-10), None})
@@ -321,23 +478,61 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         self.assertEqual(res[1], set())
         self.assertEqual(res[2], None)
 
+    def test_1DSet_UUID_type(self):
+        query = "SELECT SET['00010203-0405-0607-0809-0a0b0c0d0e0f', null]::SET[UUID], SET[]::SET[UUID], null::SET[UUID]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {UUID('00010203-0405-0607-0809-0a0b0c0d0e0f'), None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_binary_type(self):
+        query = "SELECT SET[hex_to_binary('0x41'), hex_to_binary('0x4243'), null]::SET[BINARY(2)], SET[]::SET[BINARY(4)], null::SET[BINARY]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {b'A\x00', b'BC', None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
+    def test_1DSet_varbinary_type(self):
+        query = "SELECT SET[hex_to_binary('0x41'), hex_to_binary('0x4210'), null]::SET[VARBINARY(2)], SET[]::SET[VARBINARY(4)], null::SET[VARBINARY]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {b'A', b'B\x10', None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
+
     def test_Set_dummy_type(self):
         query = "SELECT SET[]"
         res = self._query_and_fetchone(query)
         self.assertEqual(res[0], set())
 
+    #####################
+    # tests for ROW type
+    #####################
     def test_1DRow_type(self):
-        query = "SELECT ROW(null, 'Amy', -3::int, '-Infinity'::float, 2.5::numeric, '2021-10-23'::DATE, false::bool), ROW(), null::ROW(a VARCHAR)"
+        query = "SELECT ROW(null, 'Amy', -3::int, '-Infinity'::float, 2.5::numeric, '2021-10-23'::DATE, false::bool, hex_to_binary('0x4210')::VARBINARY), null::ROW(a VARCHAR)"
         res = self._query_and_fetchone(query)
-        self.assertEqual(res[0], {"f0":None,"f1":"Amy","f2":-3,"f3":float('-Inf'),"f4":Decimal('2.5'),"f5":date(2021, 10, 23),"f6":False})
-        self.assertEqual(res[1], {})
-        self.assertEqual(res[2], None)
+        self.assertEqual(res[0], {"f0":None,"f1":"Amy","f2":-3,"f3":float('-Inf'),"f4":Decimal('2.5'),"f5":date(2021, 10, 23),"f6":False, "f7":b'B\x10'})
+        self.assertEqual(res[1], None)
 
     def test_NDRow_type(self):
-        query = "SELECT ROW('Amy',25,ARRAY[1,2,3])::ROW(name varchar, age int, c ARRAY[INT])"
+        query = "SELECT ROW('Amy',ARRAY[1.5,-2,3.75],ARRAY[ARRAY[false::bool,null,true::bool]])::ROW(name varchar, b ARRAY[NUMERIC], c ARRAY[ARRAY[BOOL]])"
         res = self._query_and_fetchone(query)
-        self.assertEqual(res[0], {"name":"Amy","age":25,"c":[1,2,3]})
+        self.assertEqual(res[0], {"name":"Amy","b":[Decimal('1.5'),Decimal('-2'),Decimal('3.75')],"c":[[False,None,True]]})
 
+        query = "SELECT ROW(ROW(ARRAY[ROW(ARRAY[1,2,3]),ROW(ARRAY[4,5,6]),ROW(ARRAY[7,8,9])]::ARRAY[ROW(d3 ARRAY[INTERVAL DAY])] AS d2) AS d1)"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {"d1":{"d2":[
+            {"d3":[relativedelta(days=+1),relativedelta(days=+2),relativedelta(days=+3)]},
+            {"d3":[relativedelta(days=+4),relativedelta(days=+5),relativedelta(days=+6)]},
+            {"d3":[relativedelta(days=+7),relativedelta(days=+8),relativedelta(days=+9)]}]}})
 
+    def test_Row_dummy_type(self):
+        query = "SELECT ROW()"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {})
+
+        query = "SELECT ROW(ROW()), ROW(ARRAY[])"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {"f0":{}})
+        self.assertEqual(res[1], {"f0":[]})
 
 exec(ComplexTypeTestCase.createPrepStmtClass())

--- a/vertica_python/tests/integration_tests/test_datatypes.py
+++ b/vertica_python/tests/integration_tests/test_datatypes.py
@@ -101,14 +101,26 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         self.assertEqual(res[1], [])
         self.assertEqual(res[2], None)
 
-    # def test_1DArray_numeric_type(self):
-    #     self._test_equal_value("NUMERIC", ["0", "-1.1", "1234567890123456789.0123456789"])
-    #     self._test_equal_value("DECIMAL", ["123456789.98765"])
+    def test_1DArray_numeric_type(self):
+        query = "SELECT ARRAY[-1.12, 0, null, 1234567890123456789.0123456789]::ARRAY[NUMERIC], ARRAY[]::ARRAY[DECIMAL], null::ARRAY[NUMERIC]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [Decimal('-1.1200000000'), Decimal('0E-10'), None, Decimal('1234567890123456789.0123456789')])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    # def test_1DArray_char_type(self):
-    #     self._test_equal_value("CHAR(8)", [u"'\u16b1'"])
-    #     self._test_equal_value("VARCHAR", [u"'foo\u16b1'"])
-    #     self._test_equal_value("LONG VARCHAR", [u"'foo \u16b1 bar'"])
+    def test_1DArray_char_type(self):
+        query = u"SELECT ARRAY['a', '\u16b1b', null, 'foo']::ARRAY[CHAR(3)], ARRAY[]::ARRAY[CHAR(4)], null::ARRAY[CHAR(5)]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], ['a  ', u'\u16b1', None, 'foo'])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+    def test_1DArray_varchar_type(self):
+        query = u"SELECT ARRAY['', '\u16b1\nb', null, 'foo']::ARRAY[VARCHAR(10),4], ARRAY[]::ARRAY[VARCHAR(4)], null::ARRAY[VARCHAR]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], ['', u'\u16b1\nb', None, 'foo'])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
     def test_1DArray_date_type(self):
         query = "SELECT ARRAY['2021-06-10', null, '0221-05-02']::ARRAY[DATE], ARRAY[]::ARRAY[DATE], null::ARRAY[DATE]"
@@ -132,22 +144,111 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         self.assertEqual(res[1], [])
         self.assertEqual(res[2], None)
 
-    # def test_1DArray_timestamp_type(self):
-    # def test_1DArray_timestamptz_type(self):
-    #     self._test_equal_value("TIMESTAMP", ["'276-12-1 11:22:33'", "'2001-12-01 00:30:45.087'"])
-    #     self._test_equal_value("TIMESTAMPTZ(4)", ["'1582-09-24 00:30:45.087-08'", "'0001-1-1 11:22:33'", "'2020-12-31 10:43:09.05'"])
+    def test_1DArray_timestamp_type(self):
+        query = "SELECT ARRAY['276-12-1 11:22:33', '2001-12-01 00:30:45.087', null]::ARRAY[TIMESTAMP], ARRAY[]::ARRAY[TIMESTAMP(4)], null::ARRAY[TIMESTAMP]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [datetime(276, 12, 1, 11, 22, 33), datetime(2001, 12, 1, 0, 30, 45, 87000), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    # def test_1DArray_interval_type(self):
-    #     self._test_equal_value("INTERVAL DAY TO SECOND", ["'1 02:03:04.0005'", "'1 02:03:04'", "'02:03:04.0005'"])
-    #     self._test_equal_value("INTERVAL DAY TO MINUTE", ["'1 02:03'"])
-    #     self._test_equal_value("INTERVAL DAY TO HOUR", ["'1 22'"])
-    #     self._test_equal_value("INTERVAL DAY", ["'132'"])
-    #     self._test_equal_value("INTERVAL HOUR TO SECOND", ["'02:03:04'"])
-    #     self._test_equal_value("INTERVAL HOUR TO MINUTE", ["'02:03'"])
-    #     self._test_equal_value("INTERVAL HOUR", ["'02'"])
-    #     self._test_equal_value("INTERVAL MINUTE TO SECOND", ["'00:04.0005'", "'03:04'"])
-    #     self._test_equal_value("INTERVAL MINUTE", ["'03'"])
-    #     self._test_equal_value("INTERVAL SECOND", ["'216901.24'", "'216901'"])
+    def test_1DArray_timestamptz_type(self):
+        with self._connect() as conn:
+            cur = conn.cursor()
+            cur.execute("SET TIMEZONE 'America/Cayman'") # set session's time zone
+            cur.fetchall()
+            query = "SELECT ARRAY['276-12-1 11:22:33+0630', '2001-12-01 00:30:45.087 America/Cayman', null]::ARRAY[TIMESTAMPTZ], ARRAY[]::ARRAY[TIMESTAMPTZ(4)], null::ARRAY[TIMESTAMPTZ]"
+            cur.execute(query)
+            res = cur.fetchone()
+            self.assertEqual(res[0], [datetime(276, 11, 30, 23, 32, 57, tzinfo=tzoffset(None, -19176)),
+                                datetime(2001, 12, 1, 0, 30, 45, 87000, tzinfo=tzoffset(None, -18000)), None])
+            self.assertEqual(res[1], [])
+            self.assertEqual(res[2], None)
+
+    def test_1DArray_interval_type(self):
+        query = "SELECT ARRAY['1 02:03:04.0005', '1 02:03:04', '02:03:04.0005', '02:03', null]::ARRAY[INTERVAL DAY TO SECOND], ARRAY[]::ARRAY[INTERVAL DAY TO SECOND], null::ARRAY[INTERVAL DAY TO SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(days=+1, hours=+2, minutes=+3, seconds=+4, microseconds=+500),
+                relativedelta(days=+1, hours=+2, minutes=+3, seconds=+4),
+                relativedelta(hours=+2, minutes=+3, seconds=+4, microseconds=+500),
+                relativedelta(hours=+2, minutes=+3), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['1 02:03', '02:03', null]::ARRAY[INTERVAL DAY TO MINUTE], ARRAY[]::ARRAY[INTERVAL DAY TO MINUTE], null::ARRAY[INTERVAL DAY TO MINUTE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(days=+1, hours=+2, minutes=+3), relativedelta(hours=+2, minutes=+3), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['1 02:03', '6', '02:03', null]::ARRAY[INTERVAL DAY TO HOUR], ARRAY[]::ARRAY[INTERVAL DAY TO HOUR], null::ARRAY[INTERVAL DAY TO HOUR]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(days=+1, hours=+2), relativedelta(days=+6), relativedelta(hours=+2), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['123', '-6', null]::ARRAY[INTERVAL DAY], ARRAY[]::ARRAY[INTERVAL DAY], null::ARRAY[INTERVAL DAY]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(days=+123), relativedelta(days=-6), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['02:03:04', '02:03:04.0005', '02:03', null]::ARRAY[INTERVAL HOUR TO SECOND], ARRAY[]::ARRAY[INTERVAL HOUR TO SECOND], null::ARRAY[INTERVAL HOUR TO SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(hours=+2, minutes=+3, seconds=+4),
+                relativedelta(hours=+2, minutes=+3, seconds=+4, microseconds=+500),
+                relativedelta(hours=+2, minutes=+3), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['02:03:04', '-02:03', null]::ARRAY[INTERVAL HOUR TO MINUTE], ARRAY[]::ARRAY[INTERVAL HOUR TO MINUTE], null::ARRAY[INTERVAL HOUR TO MINUTE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(hours=+2, minutes=+3), relativedelta(hours=-2, minutes=-3), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['32', '-03', null]::ARRAY[INTERVAL HOUR], ARRAY[]::ARRAY[INTERVAL HOUR], null::ARRAY[INTERVAL HOUR]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(days=+1, hours=+8), relativedelta(hours=-3), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['00:04.0005', '03:04', null]::ARRAY[INTERVAL MINUTE TO SECOND], ARRAY[]::ARRAY[INTERVAL MINUTE TO SECOND], null::ARRAY[INTERVAL MINUTE TO SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(seconds=+4, microseconds=+500), relativedelta(minutes=+3, seconds=+4), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['03', '-34', null]::ARRAY[INTERVAL MINUTE], ARRAY[]::ARRAY[INTERVAL MINUTE], null::ARRAY[INTERVAL MINUTE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(minutes=+3), relativedelta(minutes=-34), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['216901.024', '216901', null]::ARRAY[INTERVAL SECOND], ARRAY[]::ARRAY[INTERVAL SECOND], null::ARRAY[INTERVAL SECOND]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1, microseconds=+24000), relativedelta(days=+2, hours=+12, minutes=+15, seconds=+1), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+
+    def test_1DArray_intervalYM_type(self):
+        query = "SELECT ARRAY['1y 10m', '1y', '10m ago', null]::ARRAY[INTERVAL YEAR TO MONTH], ARRAY[]::ARRAY[INTERVAL YEAR TO MONTH], null::ARRAY[INTERVAL YEAR TO MONTH]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(years=+1, months=+10), relativedelta(years=+1), relativedelta(months=-10), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['1y ago', '2y', null]::ARRAY[INTERVAL YEAR], ARRAY[]::ARRAY[INTERVAL YEAR], null::ARRAY[INTERVAL YEAR]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(years=-1), relativedelta(years=+2), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
+
+        query = "SELECT ARRAY['1y 10m', '1y', '10m ago', null]::ARRAY[INTERVAL MONTH], ARRAY[]::ARRAY[INTERVAL MONTH], null::ARRAY[INTERVAL MONTH]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [relativedelta(years=+1, months=+10), relativedelta(years=+1), relativedelta(months=-10), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
     def test_1DArray_UUID_type(self):
         query = "SELECT ARRAY['00010203-0405-0607-0809-0a0b0c0d0e0f', null]::ARRAY[UUID], ARRAY[]::ARRAY[UUID], null::ARRAY[UUID]"
@@ -156,21 +257,46 @@ class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
         self.assertEqual(res[1], [])
         self.assertEqual(res[2], None)
 
+    def test_1DArray_binary_type(self):
+        query = "SELECT ARRAY[hex_to_binary('0x41'), hex_to_binary('0x4243'), null]::ARRAY[BINARY(2)], ARRAY[]::ARRAY[BINARY(4)], null::ARRAY[BINARY]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [b'A\x00', b'BC', None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    # def test_1DArray_binary_type(self):
-    #     self._test_equal_value("BINARY(2)", [u"'\303\261'"])
-    #     self._test_equal_value("VARBINARY", [u"'\303\261'"])
-    #     self._test_equal_value("LONG VARBINARY", [u"'\303\261\303\260'"])
+    def test_1DArray_varbinary_type(self):
+        query = "SELECT ARRAY[hex_to_binary('0x41'), hex_to_binary('0x4210'), null]::ARRAY[VARBINARY(2)], ARRAY[]::ARRAY[VARBINARY(4)], null::ARRAY[VARBINARY]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [b'A', b'B\x10', None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    # def test_NDArray_type(self):
-    #     self._test_equal_value("ARRAY[INT]", ["ARRAY[1,2,3]"])
-    #     self._test_equal_value("ARRAY[ARRAY[INT]]", ["ARRAY[ARRAY[1,2],ARRAY[3,4]]"])
+    def test_NDArray_type(self):
+        query = "SELECT ARRAY[ARRAY[1,2],ARRAY[3,4],null,ARRAY[5,null],ARRAY[]]::ARRAY[ARRAY[INT]], ARRAY[]::ARRAY[ARRAY[INT]], null::ARRAY[ARRAY[INT]]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [[1,2], [3,4], None, [5,None], []])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    # def test_set_type(self):
-    #     self._test_equal_value("SET[INT]", ["SET[1,2,3]"])
+    def test_Set_type(self):
+        query = "SELECT SET[1,-2,3,null]::SET[INT], SET[]::SET[INT], null::SET[INT]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {1, -2, 3, None})
+        self.assertEqual(res[1], set())
+        self.assertEqual(res[2], None)
 
-    # def test_row_type(self):
-    #     self._test_equal_value("ROW(name varchar, age int, c ARRAY[INT])", ["ROW('Amy',25,ARRAY[1,2,3])"])
+    def test_1DRow_type(self):
+        query = "SELECT ROW(null, 'Amy', -3::int, '-Infinity'::float, 2.5::numeric, '2021-10-23'::DATE, false::bool), ROW(), null::ROW(a VARCHAR)"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {"f0":None,"f1":"Amy","f2":-3,"f3":float('-Inf'),"f4":Decimal('2.5'),"f5":date(2021, 10, 23),"f6":False})
+        self.assertEqual(res[1], '{}') # TODO
+        self.assertEqual(res[2], None)
+
+    def test_NDRow_type(self):
+        query = "SELECT ROW('Amy',25,ARRAY[1,2,3])::ROW(name varchar, age int, c ARRAY[INT])"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], {"name":"Amy","age":25,"c":[1,2,3]})
+
 
 
 exec(ComplexTypeTestCase.createPrepStmtClass())

--- a/vertica_python/tests/integration_tests/test_datatypes.py
+++ b/vertica_python/tests/integration_tests/test_datatypes.py
@@ -152,4 +152,15 @@ class DataTransferFormatTestCase(VerticaPythonIntegrationTestCase):
         self._test_equal_value("VARBINARY", [u"'\303\261'"])
         self._test_equal_value("LONG VARBINARY", [u"'\303\261\303\260'"])
 
+    def test_array_type(self):
+        self._test_equal_value("ARRAY[INT]", ["ARRAY[1,2,3]"])
+        self._test_equal_value("ARRAY[ARRAY[INT]]", ["ARRAY[ARRAY[1,2],ARRAY[3,4]]"])
+
+    def test_set_type(self):
+        self._test_equal_value("SET[INT]", ["SET[1,2,3]"])
+
+    def test_row_type(self):
+        self._test_equal_value("ROW(name varchar, age int, c ARRAY[INT])", ["ROW('Amy',25,ARRAY[1,2,3])"])
+
+
 exec(DataTransferFormatTestCase.createPrepStmtClass())

--- a/vertica_python/tests/integration_tests/test_datatypes.py
+++ b/vertica_python/tests/integration_tests/test_datatypes.py
@@ -35,6 +35,9 @@
 
 from __future__ import print_function, division, absolute_import
 
+from datetime import date, datetime, time
+from dateutil.relativedelta import relativedelta
+from dateutil.tz import tzoffset
 from decimal import Decimal
 from uuid import UUID
 
@@ -71,96 +74,103 @@ class TypeTestCase(VerticaPythonIntegrationTestCase):
 exec(TypeTestCase.createPrepStmtClass())
 
 
-"""Check the consistency of query results btw text transfer and binary transfer"""
-class DataTransferFormatTestCase(VerticaPythonIntegrationTestCase):
-    @classmethod
-    def setUpClass(cls):
-        super(DataTransferFormatTestCase, cls).setUpClass()
-        cls._conn_info['binary_transfer'] = False
-        cls.text_conn = cls._connect()
-        cls._conn_info['binary_transfer'] = True
-        cls.binary_conn = cls._connect()
-        cls.text_cursor = cls.text_conn.cursor()
-        cls.binary_cursor = cls.binary_conn.cursor()
+class ComplexTypeTestCase(VerticaPythonIntegrationTestCase):
+    def setUp(self):
+        super(ComplexTypeTestCase, self).setUp()
+        self.require_protocol_at_least(3 << 16 | 12)
 
-    @classmethod
-    def tearDownClass(cls):
-        cls.text_conn.close()
-        cls.binary_conn.close()
+    def test_1DArray_boolean_type(self):
+        query = "SELECT ARRAY['t', 'f', null]::ARRAY[BOOL], ARRAY[]::ARRAY[BOOL], null::ARRAY[BOOL]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [True, False, None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    def _test_equal_value(self, sql_type, data_list, assert_almost_equal=False):
-        for data in data_list:
-            query = u"SELECT {}{}".format(data, "::" + sql_type if sql_type else '')
-            self.text_cursor.execute(query)
-            self.binary_cursor.execute(query)
-            text_val = self.text_cursor.fetchone()[0]
-            binary_val = self.binary_cursor.fetchone()[0]
-            if assert_almost_equal:
-                self.assertAlmostEqual(text_val, binary_val)
-            else:
-                self.assertEqual(text_val, binary_val)
+    def test_1DArray_integer_type(self):
+        query = "SELECT ARRAY[-500, 0, null, 500]::ARRAY[INT], ARRAY[]::ARRAY[INT], null::ARRAY[INT]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [-500, 0, None, 500])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    def test_boolean_type(self):
-        self._test_equal_value("BOOLEAN", ['true', 'false'])
+    def test_1DArray_float_type(self):
+        query = ("SELECT ARRAY['Infinity'::float, '-Infinity'::float, null, -1.234, 0, 1.23456e-18]::ARRAY[FLOAT],"
+                 " ARRAY[]::ARRAY[FLOAT], null::ARRAY[FLOAT]")
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [float('Inf'), float('-Inf'), None, -1.234, 0.0, 1.23456e-18])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    def test_integer_type(self):
-        self._test_equal_value("INTEGER", ["-314", "0", "365", "111111111111"])
+    # def test_1DArray_numeric_type(self):
+    #     self._test_equal_value("NUMERIC", ["0", "-1.1", "1234567890123456789.0123456789"])
+    #     self._test_equal_value("DECIMAL", ["123456789.98765"])
 
-    def test_float_type(self):
-        self._test_equal_value("FLOAT", [
-            "'Infinity'", "'-Infinity'",
-            "'1.23456e+18'", "'1.23456'", "'1.23456e-18'"])
-        # binary transfer offers slightly greater precision than text transfer
-        # binary: 1.489968353486419
-        # text:   1.48996835348642
-        self._test_equal_value(None, ["ATAN(12.345)"], True)
+    # def test_1DArray_char_type(self):
+    #     self._test_equal_value("CHAR(8)", [u"'\u16b1'"])
+    #     self._test_equal_value("VARCHAR", [u"'foo\u16b1'"])
+    #     self._test_equal_value("LONG VARCHAR", [u"'foo \u16b1 bar'"])
 
-    def test_numeric_type(self):
-        self._test_equal_value("NUMERIC", ["0", "-1.1", "1234567890123456789.0123456789"])
-        self._test_equal_value("DECIMAL", ["123456789.98765"])
+    def test_1DArray_date_type(self):
+        query = "SELECT ARRAY['2021-06-10', null, '0221-05-02']::ARRAY[DATE], ARRAY[]::ARRAY[DATE], null::ARRAY[DATE]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [date(2021, 6, 10), None, date(221, 5, 2)])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    def test_char_type(self):
-        self._test_equal_value("CHAR(8)", [u"'\u16b1'"])
-        self._test_equal_value("VARCHAR", [u"'foo\u16b1'"])
-        self._test_equal_value("LONG VARCHAR", [u"'foo \u16b1 bar'"])
+    def test_1DArray_time_type(self):
+        query = "SELECT ARRAY['00:00:00.00', null, '22:36:33.123956']::ARRAY[TIME(3)], ARRAY[]::ARRAY[TIME(4)], null::ARRAY[TIME]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [time(0, 0, 0), None, time(22, 36, 33, 124000)])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    def test_datetime_type(self):
-        self._test_equal_value("DATE", ["'0340-01-20'", "'2001-12-01'", "'9999-12-31'"])
-        self._test_equal_value("TIME(3)", ["'00:00:00.00'", "'22:36:33.123956'", "'23:59:59.999'"])
-        self._test_equal_value("TIMETZ(3)", ["'23:59:59.999-00:30'", "'22:36:33.123456+0630'", "'800-02-03 22:36:33.123456 America/Cayman'"])
-        self._test_equal_value("TIMESTAMP", ["'276-12-1 11:22:33'", "'2001-12-01 00:30:45.087'"])
-        self._test_equal_value("TIMESTAMPTZ(4)", ["'1582-09-24 00:30:45.087-08'", "'0001-1-1 11:22:33'", "'2020-12-31 10:43:09.05'"])
+    def test_1DArray_timetz_type(self):
+        query = "SELECT ARRAY['22:36:33.12345+0630', null, '800-02-03 22:36:33.123456 America/Cayman']::ARRAY[TIMETZ(3)], ARRAY[]::ARRAY[TIMETZ(4)], null::ARRAY[TIMETZ]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [time(22, 36, 33, 123000, tzinfo=tzoffset(None, 23400)), None, 
+                                  time(22, 36, 33, 123000, tzinfo=tzoffset(None, -19176))])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
-    def test_interval_type(self):
-        self._test_equal_value("INTERVAL DAY TO SECOND", ["'1 02:03:04.0005'", "'1 02:03:04'", "'02:03:04.0005'"])
-        self._test_equal_value("INTERVAL DAY TO MINUTE", ["'1 02:03'"])
-        self._test_equal_value("INTERVAL DAY TO HOUR", ["'1 22'"])
-        self._test_equal_value("INTERVAL DAY", ["'132'"])
-        self._test_equal_value("INTERVAL HOUR TO SECOND", ["'02:03:04'"])
-        self._test_equal_value("INTERVAL HOUR TO MINUTE", ["'02:03'"])
-        self._test_equal_value("INTERVAL HOUR", ["'02'"])
-        self._test_equal_value("INTERVAL MINUTE TO SECOND", ["'00:04.0005'", "'03:04'"])
-        self._test_equal_value("INTERVAL MINUTE", ["'03'"])
-        self._test_equal_value("INTERVAL SECOND", ["'216901.24'", "'216901'"])
+    # def test_1DArray_timestamp_type(self):
+    # def test_1DArray_timestamptz_type(self):
+    #     self._test_equal_value("TIMESTAMP", ["'276-12-1 11:22:33'", "'2001-12-01 00:30:45.087'"])
+    #     self._test_equal_value("TIMESTAMPTZ(4)", ["'1582-09-24 00:30:45.087-08'", "'0001-1-1 11:22:33'", "'2020-12-31 10:43:09.05'"])
 
-    def test_UUID_type(self):
-        self.require_protocol_at_least(3 << 16 | 8)
-        self._test_equal_value("UUID", ["'00010203-0405-0607-0809-0a0b0c0d0e0f'", "'123e4567-e89b-12d3-a456-426655440a00'"])
+    # def test_1DArray_interval_type(self):
+    #     self._test_equal_value("INTERVAL DAY TO SECOND", ["'1 02:03:04.0005'", "'1 02:03:04'", "'02:03:04.0005'"])
+    #     self._test_equal_value("INTERVAL DAY TO MINUTE", ["'1 02:03'"])
+    #     self._test_equal_value("INTERVAL DAY TO HOUR", ["'1 22'"])
+    #     self._test_equal_value("INTERVAL DAY", ["'132'"])
+    #     self._test_equal_value("INTERVAL HOUR TO SECOND", ["'02:03:04'"])
+    #     self._test_equal_value("INTERVAL HOUR TO MINUTE", ["'02:03'"])
+    #     self._test_equal_value("INTERVAL HOUR", ["'02'"])
+    #     self._test_equal_value("INTERVAL MINUTE TO SECOND", ["'00:04.0005'", "'03:04'"])
+    #     self._test_equal_value("INTERVAL MINUTE", ["'03'"])
+    #     self._test_equal_value("INTERVAL SECOND", ["'216901.24'", "'216901'"])
 
-    def test_binary_type(self):
-        self._test_equal_value("BINARY(2)", [u"'\303\261'"])
-        self._test_equal_value("VARBINARY", [u"'\303\261'"])
-        self._test_equal_value("LONG VARBINARY", [u"'\303\261\303\260'"])
-
-    def test_array_type(self):
-        self._test_equal_value("ARRAY[INT]", ["ARRAY[1,2,3]"])
-        self._test_equal_value("ARRAY[ARRAY[INT]]", ["ARRAY[ARRAY[1,2],ARRAY[3,4]]"])
-
-    def test_set_type(self):
-        self._test_equal_value("SET[INT]", ["SET[1,2,3]"])
-
-    def test_row_type(self):
-        self._test_equal_value("ROW(name varchar, age int, c ARRAY[INT])", ["ROW('Amy',25,ARRAY[1,2,3])"])
+    def test_1DArray_UUID_type(self):
+        query = "SELECT ARRAY['00010203-0405-0607-0809-0a0b0c0d0e0f', null]::ARRAY[UUID], ARRAY[]::ARRAY[UUID], null::ARRAY[UUID]"
+        res = self._query_and_fetchone(query)
+        self.assertEqual(res[0], [UUID('00010203-0405-0607-0809-0a0b0c0d0e0f'), None])
+        self.assertEqual(res[1], [])
+        self.assertEqual(res[2], None)
 
 
-exec(DataTransferFormatTestCase.createPrepStmtClass())
+    # def test_1DArray_binary_type(self):
+    #     self._test_equal_value("BINARY(2)", [u"'\303\261'"])
+    #     self._test_equal_value("VARBINARY", [u"'\303\261'"])
+    #     self._test_equal_value("LONG VARBINARY", [u"'\303\261\303\260'"])
+
+    # def test_NDArray_type(self):
+    #     self._test_equal_value("ARRAY[INT]", ["ARRAY[1,2,3]"])
+    #     self._test_equal_value("ARRAY[ARRAY[INT]]", ["ARRAY[ARRAY[1,2],ARRAY[3,4]]"])
+
+    # def test_set_type(self):
+    #     self._test_equal_value("SET[INT]", ["SET[1,2,3]"])
+
+    # def test_row_type(self):
+    #     self._test_equal_value("ROW(name varchar, age int, c ARRAY[INT])", ["ROW('Amy',25,ARRAY[1,2,3])"])
+
+
+exec(ComplexTypeTestCase.createPrepStmtClass())

--- a/vertica_python/tests/integration_tests/test_transfer_format.py
+++ b/vertica_python/tests/integration_tests/test_transfer_format.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2022 Micro Focus or one of its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import print_function, division, absolute_import
+
+from .base import VerticaPythonIntegrationTestCase
+
+
+"""Check the consistency of query results btw text transfer and binary transfer"""
+class DataTransferFormatTestCase(VerticaPythonIntegrationTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super(DataTransferFormatTestCase, cls).setUpClass()
+        cls._conn_info['binary_transfer'] = False
+        cls.text_conn = cls._connect()
+        cls._conn_info['binary_transfer'] = True
+        cls.binary_conn = cls._connect()
+        cls.text_cursor = cls.text_conn.cursor()
+        cls.binary_cursor = cls.binary_conn.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.text_conn.close()
+        cls.binary_conn.close()
+
+    def _test_equal_value(self, sql_type, data_list, assert_almost_equal=False):
+        for data in data_list:
+            query = u"SELECT {}{}".format(data, "::" + sql_type if sql_type else '')
+            self.text_cursor.execute(query)
+            self.binary_cursor.execute(query)
+            text_val = self.text_cursor.fetchone()[0]
+            binary_val = self.binary_cursor.fetchone()[0]
+            if assert_almost_equal:
+                self.assertAlmostEqual(text_val, binary_val)
+            else:
+                self.assertEqual(text_val, binary_val)
+
+    def test_boolean_type(self):
+        self._test_equal_value("BOOLEAN", ['true', 'false'])
+
+    def test_integer_type(self):
+        self._test_equal_value("INTEGER", ["-314", "0", "365", "111111111111"])
+
+    def test_float_type(self):
+        self._test_equal_value("FLOAT", [
+            "'Infinity'", "'-Infinity'",
+            "'1.23456e+18'", "'1.23456'", "'1.23456e-18'"])
+        # binary transfer offers slightly greater precision than text transfer
+        # binary: 1.489968353486419
+        # text:   1.48996835348642
+        self._test_equal_value(None, ["ATAN(12.345)"], True)
+
+    def test_numeric_type(self):
+        self._test_equal_value("NUMERIC", ["0", "-1.1", "1234567890123456789.0123456789"])
+        self._test_equal_value("DECIMAL", ["123456789.98765"])
+
+    def test_char_type(self):
+        self._test_equal_value("CHAR(8)", [u"'\u16b1'"])
+        self._test_equal_value("VARCHAR", [u"'foo\u16b1'"])
+        self._test_equal_value("LONG VARCHAR", [u"'foo \u16b1 bar'"])
+
+    def test_datetime_type(self):
+        self._test_equal_value("DATE", ["'0340-01-20'", "'2001-12-01'", "'9999-12-31'"])
+        self._test_equal_value("TIME(3)", ["'00:00:00.00'", "'22:36:33.123956'", "'23:59:59.999'"])
+        self._test_equal_value("TIMETZ(3)", ["'23:59:59.999-00:30'", "'22:36:33.123456+0630'", "'800-02-03 22:36:33.123456 America/Cayman'"])
+        self._test_equal_value("TIMESTAMP", ["'276-12-1 11:22:33'", "'2001-12-01 00:30:45.087'"])
+        self._test_equal_value("TIMESTAMPTZ(4)", ["'1582-09-24 00:30:45.087-08'", "'0001-1-1 11:22:33'", "'2020-12-31 10:43:09.05'"])
+
+    def test_interval_type(self):
+        self._test_equal_value("INTERVAL DAY TO SECOND", ["'1 02:03:04.0005'", "'1 02:03:04'", "'02:03:04.0005'"])
+        self._test_equal_value("INTERVAL DAY TO MINUTE", ["'1 02:03'"])
+        self._test_equal_value("INTERVAL DAY TO HOUR", ["'1 22'"])
+        self._test_equal_value("INTERVAL DAY", ["'132'"])
+        self._test_equal_value("INTERVAL HOUR TO SECOND", ["'02:03:04'"])
+        self._test_equal_value("INTERVAL HOUR TO MINUTE", ["'02:03'"])
+        self._test_equal_value("INTERVAL HOUR", ["'02'"])
+        self._test_equal_value("INTERVAL MINUTE TO SECOND", ["'00:04.0005'", "'03:04'"])
+        self._test_equal_value("INTERVAL MINUTE", ["'03'"])
+        self._test_equal_value("INTERVAL SECOND", ["'216901.24'", "'216901'"])
+
+    def test_UUID_type(self):
+        self.require_protocol_at_least(3 << 16 | 8)
+        self._test_equal_value("UUID", ["'00010203-0405-0607-0809-0a0b0c0d0e0f'", "'123e4567-e89b-12d3-a456-426655440a00'"])
+
+    def test_binary_type(self):
+        self._test_equal_value("BINARY(2)", [u"'\303\261'"])
+        self._test_equal_value("VARBINARY", [u"'\303\261'"])
+        self._test_equal_value("LONG VARBINARY", [u"'\303\261\303\260'"])
+
+    def test_array_type(self):
+        self._test_equal_value("ARRAY[INT]", ["ARRAY[1,2,3]"])
+        self._test_equal_value("ARRAY[ARRAY[INT]]", ["ARRAY[ARRAY[1,2],ARRAY[3,4]]"])
+
+    def test_set_type(self):
+        self._test_equal_value("SET[INT]", ["SET[1,2,3]"])
+
+    def test_row_type(self):
+        self._test_equal_value("ROW(name varchar, age int, c ARRAY[INT])", ["ROW('Amy',25,ARRAY[1,2,3])"])
+
+
+exec(DataTransferFormatTestCase.createPrepStmtClass())

--- a/vertica_python/tests/integration_tests/test_transfer_format.py
+++ b/vertica_python/tests/integration_tests/test_transfer_format.py
@@ -79,8 +79,8 @@ class DataTransferFormatTestCase(VerticaPythonIntegrationTestCase):
         self._test_equal_value("TIMESTAMPTZ(4)", ["'1582-09-24 00:30:45.087-08'", "'0001-1-1 11:22:33'", "'2020-12-31 10:43:09.05'"])
 
     def test_interval_type(self):
-        self._test_equal_value("INTERVAL DAY TO SECOND", ["'1 02:03:04.0005'", "'1 02:03:04'", "'02:03:04.0005'"])
-        self._test_equal_value("INTERVAL DAY TO MINUTE", ["'1 02:03'"])
+        self._test_equal_value("INTERVAL DAY TO SECOND", ["'1 02:03:04.0005'", "'1 02:03:04'", "'02:03:04.0005'", "'02:03'"])
+        self._test_equal_value("INTERVAL DAY TO MINUTE", ["'1 02:03'", "'02:03'"])
         self._test_equal_value("INTERVAL DAY TO HOUR", ["'1 22'"])
         self._test_equal_value("INTERVAL DAY", ["'132'"])
         self._test_equal_value("INTERVAL HOUR TO SECOND", ["'02:03:04'"])
@@ -89,6 +89,9 @@ class DataTransferFormatTestCase(VerticaPythonIntegrationTestCase):
         self._test_equal_value("INTERVAL MINUTE TO SECOND", ["'00:04.0005'", "'03:04'"])
         self._test_equal_value("INTERVAL MINUTE", ["'03'"])
         self._test_equal_value("INTERVAL SECOND", ["'216901.24'", "'216901'"])
+        self._test_equal_value("INTERVAL YEAR", ["'1y 10m'"])
+        self._test_equal_value("INTERVAL YEAR TO MONTH", ["'1y 10m'"])
+        self._test_equal_value("INTERVAL MONTH", ["'1y 10m'"])
 
     def test_UUID_type(self):
         self.require_protocol_at_least(3 << 16 | 8)

--- a/vertica_python/tests/unit_tests/test_parsedsn.py
+++ b/vertica_python/tests/unit_tests/test_parsedsn.py
@@ -54,11 +54,11 @@ class ParseDSNTestCase(VerticaPythonUnitTestCase):
     def test_boolean_arguments(self):
         dsn = ('vertica://mike@127.0.0.1/db1?connection_load_balance=True&'
                'use_prepared_statements=0&ssl=false&disable_copy_local=on&'
-               'autocommit=true&binary_transfer=1')
+               'autocommit=true&binary_transfer=1&request_complex_types=off')
         expected = {'database': 'db1', 'connection_load_balance': True,
                     'use_prepared_statements': False,  'ssl': False,
                     'disable_copy_local': True, 'autocommit': True,
-                    'binary_transfer': True,
+                    'binary_transfer': True, 'request_complex_types': False,
                     'host': '127.0.0.1', 'user': 'mike'}
         parsed = parse_dsn(dsn)
         self.assertDictEqual(expected, parsed)

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -70,7 +70,7 @@ class Column(object):
         self.null_ok = col['null_ok']
         self.is_identity = col['is_identity']
         self.format_code = col['format_code']
-        self.child_columns = []
+        self.child_columns = None
         self.props = ColumnTuple(self.name, self.type_code, self.display_size, self.internal_size,
                                  self.precision, self.scale, self.null_ok)
 
@@ -79,6 +79,8 @@ class Column(object):
         Complex types involve multiple columns arranged in a hierarchy of parents and children.
         Each parent column stores references to child columns in a list.
         """
+        if self.child_columns is None:
+            self.child_columns = []
         self.child_columns.append(col)
 
     def __str__(self):

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -309,7 +309,8 @@ class Cursor(object):
                 self.description = self._message.get_description()
                 self._deserializers = self._des.get_row_deserializers(self.description,
                                         {'unicode_error': self.unicode_error,
-                                         'session_tz': self.connection.parameters.get('timezone', 'unknown')})
+                                         'session_tz': self.connection.parameters.get('timezone', 'unknown'),
+                                         'complex_types_enabled': self.connection.complex_types_enabled,})
             elif isinstance(self._message, messages.ReadyForQuery):
                 return None
             elif isinstance(self._message, END_OF_RESULT_RESPONSES):
@@ -369,7 +370,8 @@ class Cursor(object):
                 self.description = self._message.get_description()
                 self._deserializers = self._des.get_row_deserializers(self.description,
                                         {'unicode_error': self.unicode_error,
-                                         'session_tz': self.connection.parameters.get('timezone', 'unknown')})
+                                         'session_tz': self.connection.parameters.get('timezone', 'unknown'),
+                                         'complex_types_enabled': self.connection.complex_types_enabled,})
                 self._message = self.connection.read_message()
                 if isinstance(self._message, messages.VerifyFiles):
                     self._handle_copy_local_protocol()
@@ -660,7 +662,8 @@ class Cursor(object):
             self.description = self._message.get_description()
             self._deserializers = self._des.get_row_deserializers(self.description,
                                     {'unicode_error': self.unicode_error,
-                                     'session_tz': self.connection.parameters.get('timezone', 'unknown')})
+                                     'session_tz': self.connection.parameters.get('timezone', 'unknown'),
+                                     'complex_types_enabled': self.connection.complex_types_enabled,})
             self._message = self.connection.read_message()
             if isinstance(self._message, messages.ErrorResponse):
                 raise errors.QueryError.from_error_response(self._message, query)
@@ -853,7 +856,8 @@ class Cursor(object):
             self.description = self._message.get_description()
             self._deserializers = self._des.get_row_deserializers(self.description,
                                     {'unicode_error': self.unicode_error,
-                                     'session_tz': self.connection.parameters.get('timezone', 'unknown')})
+                                     'session_tz': self.connection.parameters.get('timezone', 'unknown'),
+                                     'complex_types_enabled': self.connection.complex_types_enabled,})
 
         # Read expected message: CommandDescription
         self._message = self.connection.read_expected_message(messages.CommandDescription, self._error_handler)

--- a/vertica_python/vertica/deserializer.py
+++ b/vertica_python/vertica/deserializer.py
@@ -499,6 +499,17 @@ def parse_array(json_data, ctx):
         parsed_array[idx] = parse_json_element(element, child_ctx)
     return parsed_array
 
+def load_row_text(val, ctx):
+    val = val.decode('utf-8', ctx['unicode_error'])
+    # Some old servers have a bug of sending ROW oid without child metadata
+    if len(ctx['column'].child_columns) == 0:
+        return val
+    return "TBD"
+
+def parse_row(json_data, ctx):
+    parsed_row = {}
+    return parsed_row
+
 def parse_json_element(element, ctx):
     type_code = ctx['column'].type_code
     if type_code in (VerticaType.BOOL, VerticaType.INT8,
@@ -521,6 +532,9 @@ def parse_json_element(element, ctx):
     # element type: list
     elif type_code == VerticaType.ARRAY:
         return parse_array(element, ctx)
+    # element type: dict
+    elif type_code == VerticaType.ROW:
+        return parse_row(element, ctx)
     return element
 
 DEFAULTS = {
@@ -581,6 +595,7 @@ DEFAULTS = {
         VerticaType.SET_BINARY: load_set_text,
         VerticaType.SET_LONGVARCHAR: load_set_text,
         VerticaType.SET_LONGVARBINARY: load_set_text,
+        VerticaType.ROW: load_row_text,
     },
     FormatCode.BINARY: {
         VerticaType.UNKNOWN: None,
@@ -639,6 +654,7 @@ DEFAULTS = {
         VerticaType.SET_BINARY: load_set_text,
         VerticaType.SET_LONGVARCHAR: load_set_text,
         VerticaType.SET_LONGVARBINARY: load_set_text,
+        VerticaType.ROW: load_row_text,
     },
 }
 

--- a/vertica_python/vertica/deserializer.py
+++ b/vertica_python/vertica/deserializer.py
@@ -465,15 +465,6 @@ def load_varbinary_text(s, ctx):
         buf.append(c)
     return b''.join(buf)
 
-def load_json_text(val, ctx):
-    """
-    Parses text/binary representation of a complex type with default JSONDecoder.
-    :param val: bytes
-    :param ctx: dict
-    :return: list or dict
-    """
-    return json.loads(val.decode('utf-8', ctx['unicode_error']))
-
 def load_array_text(val, ctx):
     """
     Parses text/binary representation of an ARRAY type.
@@ -503,6 +494,12 @@ def parse_array(json_data, ctx):
     # An array has only one child, all elements in the array are the same type.
     child_ctx = ctx.copy()
     child_ctx['column'] = ctx['column'].child_columns[0]
+
+    # Shortcut: return data parsed by the default JSONDecoder
+    if child_ctx['column'].type_code in (VerticaType.BOOL, VerticaType.INT8,
+                    VerticaType.CHAR, VerticaType.VARCHAR, VerticaType.LONGVARCHAR):
+        return json_data
+
     parsed_array = [None] * len(json_data)
     for idx, element in enumerate(json_data):
         if element is None:
@@ -594,13 +591,13 @@ DEFAULTS = {
         VerticaType.VARBINARY: load_varbinary_text,
         VerticaType.LONGVARBINARY: load_varbinary_text,
         VerticaType.ARRAY: load_array_text,
-        VerticaType.ARRAY1D_BOOL: load_json_text,
-        VerticaType.ARRAY1D_INT8: load_json_text,
+        VerticaType.ARRAY1D_BOOL: load_array_text,
+        VerticaType.ARRAY1D_INT8: load_array_text,
         VerticaType.ARRAY1D_FLOAT8: load_array_text,
         VerticaType.ARRAY1D_NUMERIC: load_array_text,
-        VerticaType.ARRAY1D_CHAR: load_json_text,
-        VerticaType.ARRAY1D_VARCHAR: load_json_text,
-        VerticaType.ARRAY1D_LONGVARCHAR: load_json_text,
+        VerticaType.ARRAY1D_CHAR: load_array_text,
+        VerticaType.ARRAY1D_VARCHAR: load_array_text,
+        VerticaType.ARRAY1D_LONGVARCHAR: load_array_text,
         VerticaType.ARRAY1D_DATE: load_array_text,
         VerticaType.ARRAY1D_TIME: load_array_text,
         VerticaType.ARRAY1D_TIMETZ: load_array_text,
@@ -654,13 +651,13 @@ DEFAULTS = {
         VerticaType.VARBINARY: None,
         VerticaType.LONGVARBINARY: None,
         VerticaType.ARRAY: load_array_text,
-        VerticaType.ARRAY1D_BOOL: load_json_text,
-        VerticaType.ARRAY1D_INT8: load_json_text,
+        VerticaType.ARRAY1D_BOOL: load_array_text,
+        VerticaType.ARRAY1D_INT8: load_array_text,
         VerticaType.ARRAY1D_FLOAT8: load_array_text,
         VerticaType.ARRAY1D_NUMERIC: load_array_text,
-        VerticaType.ARRAY1D_CHAR: load_json_text,
-        VerticaType.ARRAY1D_VARCHAR: load_json_text,
-        VerticaType.ARRAY1D_LONGVARCHAR: load_json_text,
+        VerticaType.ARRAY1D_CHAR: load_array_text,
+        VerticaType.ARRAY1D_VARCHAR: load_array_text,
+        VerticaType.ARRAY1D_LONGVARCHAR: load_array_text,
         VerticaType.ARRAY1D_DATE: load_array_text,
         VerticaType.ARRAY1D_TIME: load_array_text,
         VerticaType.ARRAY1D_TIMETZ: load_array_text,

--- a/vertica_python/vertica/deserializer.py
+++ b/vertica_python/vertica/deserializer.py
@@ -48,7 +48,9 @@ class Deserializer(object):
         def deserializer(data):
             if data is None: # null
                 return None
-            return f(data, ctx={'column': col, **context})
+            ctx = {'column': col}
+            ctx.update(context)
+            return f(data, ctx=ctx)
         return deserializer
 
 
@@ -629,6 +631,7 @@ DEFAULTS = {
         VerticaType.SET_LONGVARCHAR: load_set_text,
         VerticaType.SET_LONGVARBINARY: load_set_text,
         VerticaType.ROW: load_row_text,
+        VerticaType.MAP: load_row_text,
     },
     FormatCode.BINARY: {
         VerticaType.UNKNOWN: None,
@@ -688,6 +691,7 @@ DEFAULTS = {
         VerticaType.SET_LONGVARCHAR: load_set_text,
         VerticaType.SET_LONGVARBINARY: load_set_text,
         VerticaType.ROW: load_row_text,
+        VerticaType.MAP: load_row_text,
     },
 }
 

--- a/vertica_python/vertica/messages/frontend_messages/startup.py
+++ b/vertica_python/vertica/messages/frontend_messages/startup.py
@@ -55,7 +55,8 @@ from ..message import BulkFrontendMessage
 class Startup(BulkFrontendMessage):
     message_id = None
 
-    def __init__(self, user, database, session_label, os_user_name, autocommit, binary_transfer):
+    def __init__(self, user, database, session_label, os_user_name, autocommit,
+                 binary_transfer, request_complex_types):
         BulkFrontendMessage.__init__(self)
 
         try:
@@ -70,6 +71,8 @@ class Startup(BulkFrontendMessage):
             pid = '0'
             print("WARN: Cannot get the process ID: {}".format(str(e)))
 
+        request_complex_types = 'true' if request_complex_types else 'false'
+
         self.parameters = {
             b'user': user,
             b'database': database,
@@ -81,7 +84,7 @@ class Startup(BulkFrontendMessage):
             b'client_pid': pid,
             b'autocommit': 'on' if autocommit else 'off',
             b'binary_data_protocol': '1' if binary_transfer else '0', # Defaults to text format '0'
-            b'protocol_features': '{"request_complex_types":true}',
+            b'protocol_features': '{"request_complex_types":' + request_complex_types + '}',
         }
 
     def read_bytes(self):


### PR DESCRIPTION
Partial fix for #469.

- Parse ROW type data into a dict.
- Add connection knob 'request_complex_types'.
- Add tests.