### PR TITLE
deprecate crypt package

### DIFF
--- a/vertica_python/vertica/messages/backend_messages/authentication.py
+++ b/vertica_python/vertica/messages/backend_messages/authentication.py
@@ -48,7 +48,7 @@ class Authentication(BackendMessage):
     KERBEROS_V4 = 1
     KERBEROS_V5 = 2
     CLEARTEXT_PASSWORD = 3
-    CRYPT_PASSWORD = 4
+    CRYPT_PASSWORD = 4  # obsolete
     MD5_PASSWORD = 5
     SCM_CREDENTIAL = 6
     GSS = 7

--- a/vertica_python/vertica/messages/frontend_messages/password.py
+++ b/vertica_python/vertica/messages/frontend_messages/password.py
@@ -43,10 +43,7 @@ from ..message import BulkFrontendMessage
 from ..backend_messages.authentication import Authentication
 from ....compat import as_bytes
 
-if os.name == 'nt':
-    from . import crypt_windows as crypt
-else:
-    import crypt
+from . import crypt_windows as crypt
 
 
 class Password(BulkFrontendMessage):


### PR DESCRIPTION
This is a change regarding the DeprecationWarning found in Python 3.11 tests.
```
../vertica_python/vertica/messages/frontend_messages/password.py:49: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
    import crypt
```