### PR TITLE
Close socket on tls n response

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -541,7 +541,7 @@ class Connection(object):
         else:
             err_msg = "SSL requested but not supported by server"
             self._logger.error(err_msg)
-            raw_socket.close()
+            self.close_socket()
             raise errors.SSLNotSupported(err_msg)
         return raw_socket
 

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -541,6 +541,7 @@ class Connection(object):
         else:
             err_msg = "SSL requested but not supported by server"
             self._logger.error(err_msg)
+            raw_socket.close()
             raise errors.SSLNotSupported(err_msg)
         return raw_socket
 


### PR DESCRIPTION
Small change to make sure the socket is closed when SSL negotiation winds up restricting the opening of an SSL Socket. 