### PR TITLE
Send cancel() when receive Ctrl-C

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -182,6 +182,7 @@ class Cursor(object):
             except KeyboardInterrupt:
                 self.connection.cancel()
                 self.flush_to_query_ready() # ignore errors.QueryCanceled
+                raise
         return wrap
 
     #############################################

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -173,6 +173,9 @@ class Cursor(object):
     # decorators
     #############################################
     def handle_ctrl_c(func):
+        """
+        On Ctrl-C, try to cancel the query in the server
+        """
         def wrap(self, *args, **kwargs):
             try:
                 return func(self, *args, **kwargs)
@@ -193,7 +196,7 @@ class Cursor(object):
             self._close_prepared_statement()
         self._closed = True
 
-    #@handle_ctrl_c
+    @handle_ctrl_c
     def execute(self, operation, parameters=None, use_prepared_statements=None,
                 copy_stdin=None, buffer_size=DEFAULT_BUFFER_SIZE):
         # type: (str, Optional[Union[List[Any], Tuple[Any], Dict[str, Any]]], Optional[bool], Optional[Union[IO[AnyStr], List[IO[AnyStr]]]], int) -> Self

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -181,6 +181,7 @@ class Cursor(object):
                 return func(self, *args, **kwargs)
             except KeyboardInterrupt:
                 self.connection.cancel()
+                self.flush_to_query_ready() # ignore errors.QueryCanceled
         return wrap
 
     #############################################
@@ -244,6 +245,7 @@ class Cursor(object):
 
         return self
 
+    @handle_ctrl_c
     def executemany(self, operation, seq_of_parameters, use_prepared_statements=None):
         # type: (str, Sequence[Union[List[Any], Tuple[Any], Dict[str, Any]]], Optional[bool]) -> None
 

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -170,6 +170,17 @@ class Cursor(object):
         self.close()
 
     #############################################
+    # decorators
+    #############################################
+    def handle_ctrl_c(func):
+        def wrap(self, *args, **kwargs):
+            try:
+                return func(self, *args, **kwargs)
+            except KeyboardInterrupt:
+                self.connection.cancel()
+        return wrap
+
+    #############################################
     # dbapi methods
     #############################################
     # noinspection PyMethodMayBeStatic
@@ -182,6 +193,7 @@ class Cursor(object):
             self._close_prepared_statement()
         self._closed = True
 
+    #@handle_ctrl_c
     def execute(self, operation, parameters=None, use_prepared_statements=None,
                 copy_stdin=None, buffer_size=DEFAULT_BUFFER_SIZE):
         # type: (str, Optional[Union[List[Any], Tuple[Any], Dict[str, Any]]], Optional[bool], Optional[Union[IO[AnyStr], List[IO[AnyStr]]]], int) -> Self
@@ -914,3 +926,4 @@ class Cursor(object):
         self.connection.write(messages.Flush())
         self._message = self.connection.read_expected_message(messages.CloseComplete)
         self.connection.write(messages.Sync())
+


### PR DESCRIPTION
Handle KeyboardInterrupt (Ctrl-C) for long running queries.

The client will catch the keyboard interrupt during executing the command (`Cursor.execute()` or `Cursor.executemany()`), send a cancel request to the database, return the keyboard interrupt to the caller.