### PR TITLE
Insert complex types with client-side binding 

### DIFF
--- a/README.md
+++ b/README.md
@@ -569,8 +569,11 @@ In order to merge the query (with placeholders) and the parameters on the client
 from datetime import date
 cur.execute("CREATE TABLE table (a INT, b ARRAY[DATE])")
 value = [date(2021, 6, 10), date(2021, 6, 12), date(2021, 6, 30)]
+
 cur.execute("INSERT INTO table VALUES (%s, %s)", [100, value], use_prepared_statements=False)  # WRONG
-# Error Message: Column "b" is of type array[date] but expression is of type array[varchar], Sqlstate: 42804, Hint: You will need to rewrite or cast the expression
+# Error Message: Column "b" is of type array[date] but expression is of type array[varchar], Sqlstate: 42804, 
+# Hint: You will need to rewrite or cast the expression
+
 cur.execute("INSERT INTO table VALUES (%s, %s::ARRAY[DATE])", [100, value], use_prepared_statements=False)  # correct
 # converted into a SQL command: INSERT INTO vptest VALUES (100, ARRAY['2021-06-10','2021-06-12','2021-06-30']::ARRAY[DATE])
 ```

--- a/README.md
+++ b/README.md
@@ -529,27 +529,27 @@ Note: In other drivers, the batch insert is converted into a COPY statement by u
 
 #### Client-side binding: Query using named parameters or format parameters
 
-vertica-python can automatically convert Python objects to SQL literals, merge the query and the parameters on the client side, and then send the query to the server: using this feature your code will be more robust and reliable to prevent SQL injection attacks.
+vertica-python can automatically convert Python objects to SQL literals, merge the query and the parameters on the client side, and then send the query to the server: using this feature your code will be more robust and reliable to prevent SQL injection attacks. You need to set ```use_prepared_statements``` option to __False__ (at connection level or in cursor.execute*()) to use client-side binding.
 
 Variables can be specified with named (__:name__) placeholders.
 ```python
 cur = connection.cursor()
 data = {'propA': 1, 'propB': 'stringValue'}
-cur.execute("SELECT * FROM a_table WHERE a = :propA AND b = :propB", data)
+cur.execute("SELECT * FROM a_table WHERE a = :propA AND b = :propB", data, use_prepared_statements=False)
 # converted into a SQL command similar to: "SELECT * FROM a_table WHERE a = 1 AND b = 'stringValue'"
 
 cur.fetchall()
 # [ [1, 'stringValue'] ]
 ```
 
-Variables can also be specified with positional format (__%s__) placeholders. The placeholder __must always be a %s__, even if a different placeholder (such as a %d for integers or %f for floats) may look more appropriate. __Never__ use Python string concatenation (+) or string parameters interpolation (%) to pass variables to a SQL query string.
+Variables can also be specified with positional format (__%s__) placeholders. The placeholder __must always be a %s__, even if a different placeholder (such as a `%d` for integers or `%f` for floats) may look more appropriate. __Never__ use Python string concatenation (+) or string parameters interpolation (%) to pass variables to a SQL query string.
 ```python
 cur = connection.cursor()
 data = (1, "O'Reilly")
 cur.execute("SELECT * FROM a_table WHERE a = %s AND b = %s" % data) # WRONG: % operator
 cur.execute("SELECT * FROM a_table WHERE a = %d AND b = %s", data)  # WRONG: %d placeholder
 cur.execute("SELECT * FROM a_table WHERE a = %s AND b = %s", data)  # correct
-# converted into a SQL command similar to: "SELECT * FROM a_table WHERE a = 1 AND b = 'O''Reilly'"
+# converted into a SQL command: SELECT * FROM a_table WHERE a = 1 AND b = 'O''Reilly'
 
 cur.fetchall()
 # [ [1, "O'Reilly"] ]
@@ -563,7 +563,17 @@ The placeholder must not be quoted. _vertica-python_ will add quotes where neede
 >>> cur.execute("INSERT INTO table VALUES (%s)", ("someString",))   # correct
 ```
 
-_vertica-python_ supports default mapping for many standard Python types. It is possible to adapt new Python types to SQL literals via `Cursor.register_sql_literal_adapter(py_class_or_type, adapter_function)` function. Example:
+_vertica-python_ supports default mapping for many standard Python types. For complex types, in some cases, you may need explicit typecasting for the placeholder (e.g. `%s::ARRAY[ARRAY[INT]]`):
+```python
+from datetime import date
+cur.execute("CREATE TABLE table (a INT, b ARRAY[DATE])")
+value = [date(2021, 6, 10), date(2021, 6, 12), date(2021, 6, 30)]
+cur.execute("INSERT INTO table VALUES (%s, %s::ARRAY[DATE])", [100, value], use_prepared_statements=False)
+# converted into a SQL command: INSERT INTO vptest VALUES (100, ARRAY['2021-06-10','2021-06-12','2021-06-30']::ARRAY[DATE])
+```
+
+##### Register SQL literal adapters
+It is possible to adapt new Python types to SQL literals via `Cursor.register_sql_literal_adapter(py_class_or_type, adapter_function)` function. Example:
 ```python
 class Point(object):
     def __init__(self, x, y):

--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -697,9 +697,9 @@ class SimpleQueryTestCase(VerticaPythonIntegrationTestCase):
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute("CREATE TABLE {0} (a INT, b VARCHAR)".format(self._table))
-            err_msg = 'not all arguments converted during string formatting'
+            err_msg = 'Invalid SQL'
             values = [1, 'aa']
-            with pytest.raises(TypeError, match=err_msg):
+            with pytest.raises(ValueError, match=err_msg):
                 cur.execute("INSERT INTO {} VALUES (?, ?)".format(self._table), values)
 
             cur.execute("INSERT INTO {} VALUES (?, ?)".format(self._table),
@@ -1189,9 +1189,9 @@ class PreparedStatementTestCase(VerticaPythonIntegrationTestCase):
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute("CREATE TABLE {} (a int, b varchar)".format(self._table))
-            err_msg = 'Syntax error at or near "%"'
+            err_msg = 'Invalid SQL'
             values = [1, 'varchar']
-            with pytest.raises(errors.VerticaSyntaxError, match=err_msg):
+            with pytest.raises(ValueError, match=err_msg):
                 cur.execute("INSERT INTO {} VALUES (%s, %s)".format(self._table), values)
 
             cur.execute("INSERT INTO {} VALUES (%s, %s)".format(self._table),

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -83,6 +83,18 @@ class Column(object):
             self.child_columns = []
         self.child_columns.append(col)
 
+    def debug_info(self):
+        childs = ""
+        if self.child_columns:
+            c = ", ".join([col.debug_info() for col in self.child_columns])
+            childs = f", child_columns=[{c}]"
+        return (f"Column(name={self.name}, data_type_oid={self.type_code}, data_type_name={self.type_name}, "
+                f"schema_name={self.schema_name}, table_name={self.table_name}, table_oid={self.table_oid}, "
+                f"attribute_number={self.attribute_number}, precision={self.precision}, scale={self.scale}, "
+                f"null_ok={self.null_ok}, is_identity={self.is_identity}, format_code={self.format_code}, "
+                f"internal_size={self.internal_size}, display_size={self.display_size}{childs}"
+                ")")
+
     def __str__(self):
         return as_str(str(self.props))
 

--- a/vertica_python/vertica/messages/backend_messages/row_description.py
+++ b/vertica_python/vertica/messages/backend_messages/row_description.py
@@ -149,7 +149,8 @@ class RowDescription(BackendMessage):
         return self.fields
 
     def __str__(self):
-        return "RowDescription: {}".format(self.fields)
+        s = ",\n".join([c.debug_info() for c in self.fields])
+        return f"RowDescription: [\n{s}]"
 
 
 BackendMessage.register(RowDescription)


### PR DESCRIPTION
- [use_prepared_statements=False only] Add default mappings from python types (_list_, _set_, _dict_) to SQL literals (ARRAY, SET, ROW)
- Improve error message and debug logging