### PR TITLE
handle decode error for command complete messages

### DIFF
--- a/vertica_python/vertica/messages/backend_messages/command_complete.py
+++ b/vertica_python/vertica/messages/backend_messages/command_complete.py
@@ -55,7 +55,7 @@ class CommandComplete(BackendMessage):
     def __init__(self, data):
         BackendMessage.__init__(self)
         data = unpack('{0}sx'.format(len(data) - 1), data)[0]
-        self.command_tag = data.decode('utf-8')
+        self.command_tag = data.decode('utf-8', 'replace')
 
     def __str__(self):
         return 'CommandComplete: command_tag = "{}"'.format(self.command_tag)


### PR DESCRIPTION
**Issue**

Similar to: https://github.com/vertica/vertica-python/issues/457

In class `CommandComplete` it is possible for a `UnicodeDecodeError` to be raised.
