### PR TITLE
Quick workaround for #493

### DIFF
--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -59,8 +59,8 @@ __all__ = ['Connection', 'PROTOCOL_VERSION', 'version_info', 'apilevel', 'thread
 version_info = (1, 3, 1)
 __version__ = '.'.join(map(str, version_info))
 
-# The protocol version (3.12) implemented in this library.
-PROTOCOL_VERSION = 3 << 16 | 12
+# The protocol version (3.13) implemented in this library.
+PROTOCOL_VERSION = 3 << 16 | 13
 
 apilevel = 2.0
 threadsafety = 1  # Threads may share the module, but not connections!

--- a/vertica_python/vertica/messages/backend_messages/command_complete.py
+++ b/vertica_python/vertica/messages/backend_messages/command_complete.py
@@ -55,7 +55,11 @@ class CommandComplete(BackendMessage):
     def __init__(self, data):
         BackendMessage.__init__(self)
         data = unpack('{0}sx'.format(len(data) - 1), data)[0]
-        self.command_tag = data.decode('utf-8')
+        try:
+            self.command_tag = data.decode('utf-8')
+        except UnicodeDecodeError as e:
+            # (workaround for #493) something wrong in the server, hide the problem for now
+            self.command_tag = data.decode('utf-8', 'backslashreplace')
 
     def __str__(self):
         return 'CommandComplete: command_tag = "{}"'.format(self.command_tag)

--- a/vertica_python/vertica/messages/backend_messages/notice_response.py
+++ b/vertica_python/vertica/messages/backend_messages/notice_response.py
@@ -99,7 +99,7 @@ class NoticeResponse(_NoticeResponseAttrMixin, BackendMessage):
             unpacked = unpack_from('c{0}sx'.format(null_byte - 1 - pos), data, pos)
             key = unpacked[0]
             value = unpacked[1]
-            data_mapping[key] = value.decode('utf-8', 'replace')
+            data_mapping[key] = value.decode('utf-8', 'backslashreplace')
 
             pos += (len(value) + 2)
 

--- a/vertica_python/vertica/messages/frontend_messages/startup.py
+++ b/vertica_python/vertica/messages/frontend_messages/startup.py
@@ -85,6 +85,7 @@ class Startup(BulkFrontendMessage):
             b'autocommit': 'on' if autocommit else 'off',
             b'binary_data_protocol': '1' if binary_transfer else '0', # Defaults to text format '0'
             b'protocol_features': '{"request_complex_types":' + request_complex_types + '}',
+            b'protocol_compat': 'VER',
         }
 
     def read_bytes(self):


### PR DESCRIPTION
- Quick workaround for #493
- Update protocol version to 3.13
- Change decoding [error handlers](https://docs.python.org/3/library/codecs.html#error-handlers) from 'replace' to 'backslashreplace' as we don't support Python 2 anymore.