### PR TITLE
[#510] proxy support while establishing socket connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ import vertica_python
 
 conn_info = {'host': '127.0.0.1',
              'port': 5433,
+             'proxy': 'proxy.svc.local:3128', #optional
              'user': 'some_user',
              'password': 'some_password',
              'database': 'a_database',
@@ -90,6 +91,7 @@ with vertica_python.connect(**conn_info) as connection:
 | ------------- | ------------- |
 | host     | The server host of the connection. This can be a host name or an IP address. <br>**_Default_**: "localhost" |
 | port     | The port of the connection. <br>**_Default_**: 5433 |
+| proxy    | The proxy server host:port. <br>**_Default_**: "" (None) |
 | user     | The database user name to use to connect to the database. <br>**_Default_**: OS login user name |
 | password | The password to use to log into the database. <br>**_Default_**: "" |
 | database | The database name. <br>**_Default_**: "" |

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -603,6 +603,21 @@ class Connection(object):
 
                     statusline = fp.readline().rstrip('\r\n')
                     print(f'Proxy response is: {statusline}')
+                    if statusline.count(' ') < 2:
+                        fp.close()
+                        raw_socket.close()
+                        raise IOError('Bad response')
+                    version, status, statusmsg = statusline.split(' ', 2)
+                    if not version in ('HTTP/1.0', 'HTTP/1.1'):
+                        fp.close()
+                        raw_socket.close()
+                        raise IOError('Unsupported HTTP version')
+                    try:
+                        status = int(status)
+                    except ValueError:
+                        fp.close()
+                        raw_socket.close()
+                        raise IOError('Bad response')
                 else:
                     raw_socket.connect(sockaddr)
                 break

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -598,7 +598,7 @@ class Connection(object):
                     proxy_tuple=(self.proxy.rsplit(':', 1)[0], int(self.proxy.rsplit(':', 1)[1]))
                     raw_socket.connect(proxy_tuple)
                     fp = raw_socket.makefile(mode='rw')
-                    fp.write('CONNECT %s:%d HTTP/1.0\r\n\r\n' % (host, port))
+                    fp.write('CONNECT %s:%d HTTP/1.1\r\n\r\n' % (host, port))
                     fp.flush()
 
                     statusline = fp.readline().rstrip('\r\n')

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -221,7 +221,7 @@ class _AddressList(object):
                 host, port, proxy = entry.host, entry.data, entry.proxy
                 try:
                     if proxy:
-                        proxy_host, proxy_port = proxy.split(':')
+                        proxy_host, proxy_port = proxy.rsplit(':', 1)
                         resolved_hosts = socket.getaddrinfo(proxy_host, proxy_port, 0, socket.SOCK_STREAM)
                     else:
                         resolved_hosts = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
@@ -594,7 +594,7 @@ class Connection(object):
                 raw_socket = self.create_socket(family)
                 if self.proxy:
                     self._logger.info(f'Connecting to proxy: {self.proxy}')
-                    proxy_tuple=(self.proxy.split(':')[0], int(self.proxy.split(':')[1]))
+                    proxy_tuple=(self.proxy.rsplit(':', 1)[0], int(self.proxy.rsplit(':', 1)[1]))
                     raw_socket.connect(proxy_tuple)
                     fp = raw_socket.makefile(mode='rw')
                     fp.write('CONNECT %s:%d HTTP/1.0\r\n\r\n' % (host, port))

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -307,6 +307,7 @@ class Connection(object):
         # the correct value cannot be overwritten by load balancing or failover
         self.options.setdefault('kerberos_host_name', self.options['host'])
 
+        self.proxy=None
         if 'proxy' in self.options and self.options['proxy']:
             self.proxy = self.options['proxy']
 

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -162,9 +162,9 @@ class _AddressList(object):
         # a (host, port) tuple
         for node in backup_nodes:
             if isinstance(node, str):
-                self._append(node, DEFAULT_PORT)
+                self._append(node, DEFAULT_PORT, proxy)
             elif isinstance(node, tuple) and len(node) == 2:
-                self._append(node[0], node[1])
+                self._append(node[0], node[1], proxy)
             else:
                 err_msg = ('Each item of connection option "backup_server_node"'
                            ' must be a host string or a (host, port) tuple')


### PR DESCRIPTION
Fix #510
* Maintains proxy information in _AddressEntry (if its available)
* Do not resolve dns using peek if the proxy is configured. Since, most of the cloud proxies do not allow dns resolutions
* Use proxy while establishing connection using socket when its configured
* Updated README