### PR TITLE
Change notice format

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -687,7 +687,9 @@ class Connection(object):
             if getattr(self, 'notice_handler', None) is not None:
                 self.notice_handler(message)
             else:
-                notice = f'[{message.severity}] {message.message}'
+                notice = f'{message.severity} {message.error_code}: {message.message}'
+                if message.hint is not None:
+                    notice += f'\nHINT: {message.hint}'
                 warnings.warn(notice)
                 self._logger.warning(message.error_message())
 


### PR DESCRIPTION
Server send notice message, and vertica-python shows it as a warning message

Previous format: `[NOTICE] No users were dropped`
Now: `NOTICE 4185: Nothing was dropped`