### PR TITLE
Fix cursor.copy() typing

### DIFF
--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -464,7 +464,7 @@ class Cursor(object):
             yield row
             row = self.fetchone()
 
-    def copy(self, sql: str, data: IO[AnyStr], **kwargs: Any) -> None:
+    def copy(self, sql: str, data: Union[IO[AnyStr], bytes, str], **kwargs: Any) -> None:
         """
         Execute a "COPY FROM STDIN" SQL.
 


### PR DESCRIPTION
Add str and bytes which are already handled