### PR TITLE
Allowing for refresh token rotation during token refresh request

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -920,7 +920,7 @@ class Connection(object):
                     # If access token is not set, will attempt to set a new one by using token refresh
                     if len(self.oauth_access_token) == 0 and self.oauth_manager and not self.oauth_manager.refresh_attempted:
                         self._logger.info("Issuing an OAuth access token using a refresh token")
-                        self.oauth_access_token = self.oauth_manager.do_token_refresh()
+                        self.oauth_access_token, self.oauth_refresh_token = self.oauth_manager.do_token_refresh()
                     self.write(messages.Password(self.oauth_access_token, message.code))
                 else:
                     self.write(messages.Password(password, message.code,
@@ -940,7 +940,7 @@ class Connection(object):
                         raise errors.ConnectionError("Did not receive proper OAuth Authentication response from server. Please upgrade to the latest Vertica server for OAuth Support.")
                     self.close_socket()
                     self._logger.info("Issuing a new OAuth access token using a refresh token")
-                    self.oauth_access_token = self.oauth_manager.do_token_refresh()
+                    self.oauth_access_token, self.oauth_refresh_token = self.oauth_manager.do_token_refresh()
                     return True
                 raise errors.ConnectionError(message.error_message())
             else:

--- a/vertica_python/vertica/oauth_manager.py
+++ b/vertica_python/vertica/oauth_manager.py
@@ -80,7 +80,12 @@ class OAuthManager:
             # TODO handle self.validate_cert_hostname
             response = requests.post(self.token_url, headers=headers, data=params, verify=False)
             response.raise_for_status()
-            return response.json()["access_token"]
+            json_response = response.json()
+            # If refresh token rotation is used, like in OTDS, we will get both our new valid access token as well as
+            # a new refresh token to use the next time we need to invoke token refresh.
+            if 'refresh_token' in json_response:
+                self.refresh_token = json_response["refresh_token"]
+            return response.json()["access_token"], self.refresh_token
         except requests.exceptions.HTTPError as err:
             msg = f'{err_msg}\n{err}\n{response.json()}'
             raise OAuthTokenRefreshError(msg)


### PR DESCRIPTION
Modifying 'get_access_token_using_refresh_token' to return both access and refresh tokens, which gets passed through 'do_token_refresh'. 

The access token being returned is unchanged. The refresh token being returned is either the same value that is currently saved in the connection in the case that we are not using refresh token rotation. If we are using refresh token rotation, like with OTDS, then we receive a new refresh token every time we use one. This means we have to update what is saved on the connection so that we can get this refresh token programmatically in case we want to do token refresh again. 