### PR TITLE
remove Python2 crumbs

### DIFF
--- a/vertica_python/__init__.py
+++ b/vertica_python/__init__.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .vertica.connection import Connection, connect, parse_dsn
 

--- a/vertica_python/compat.py
+++ b/vertica_python/compat.py
@@ -63,10 +63,6 @@ The compatibility module also provides the following types:
 * `real_types`
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import six as _six
 
 

--- a/vertica_python/datatypes.py
+++ b/vertica_python/datatypes.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from datetime import date, datetime, time, timezone
 from typing import TYPE_CHECKING

--- a/vertica_python/errors.py
+++ b/vertica_python/errors.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import re
 

--- a/vertica_python/os_utils.py
+++ b/vertica_python/os_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import errno
 import os

--- a/vertica_python/tests/common/base.py
+++ b/vertica_python/tests/common/base.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import os
 import sys

--- a/vertica_python/tests/integration_tests/base.py
+++ b/vertica_python/tests/integration_tests/base.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import pytest
 

--- a/vertica_python/tests/integration_tests/test_authentication.py
+++ b/vertica_python/tests/integration_tests/test_authentication.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonIntegrationTestCase
 

--- a/vertica_python/tests/integration_tests/test_cancel.py
+++ b/vertica_python/tests/integration_tests/test_cancel.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from multiprocessing import Process
 import pytest

--- a/vertica_python/tests/integration_tests/test_column.py
+++ b/vertica_python/tests/integration_tests/test_column.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonIntegrationTestCase
 

--- a/vertica_python/tests/integration_tests/test_connection.py
+++ b/vertica_python/tests/integration_tests/test_connection.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import getpass
 import socket

--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from datetime import date, datetime, time
 from dateutil.relativedelta import relativedelta

--- a/vertica_python/tests/integration_tests/test_datatypes.py
+++ b/vertica_python/tests/integration_tests/test_datatypes.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from datetime import date, datetime, time
 from dateutil.relativedelta import relativedelta

--- a/vertica_python/tests/integration_tests/test_dates.py
+++ b/vertica_python/tests/integration_tests/test_dates.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from collections import namedtuple
 from datetime import date

--- a/vertica_python/tests/integration_tests/test_errors.py
+++ b/vertica_python/tests/integration_tests/test_errors.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonIntegrationTestCase
 

--- a/vertica_python/tests/integration_tests/test_loadbalance.py
+++ b/vertica_python/tests/integration_tests/test_loadbalance.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonIntegrationTestCase
 

--- a/vertica_python/tests/integration_tests/test_timezones.py
+++ b/vertica_python/tests/integration_tests/test_timezones.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from collections import namedtuple
 from datetime import datetime

--- a/vertica_python/tests/integration_tests/test_tls.py
+++ b/vertica_python/tests/integration_tests/test_tls.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import os
 import socket

--- a/vertica_python/tests/integration_tests/test_transfer_format.py
+++ b/vertica_python/tests/integration_tests/test_transfer_format.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonIntegrationTestCase
 

--- a/vertica_python/tests/integration_tests/test_unicode.py
+++ b/vertica_python/tests/integration_tests/test_unicode.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonIntegrationTestCase
 

--- a/vertica_python/tests/unit_tests/base.py
+++ b/vertica_python/tests/unit_tests/base.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import pytest
 from ..common.base import VerticaPythonTestCase

--- a/vertica_python/tests/unit_tests/test_errors.py
+++ b/vertica_python/tests/unit_tests/test_errors.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonUnitTestCase
 from ...errors import VerticaSyntaxError

--- a/vertica_python/tests/unit_tests/test_logging.py
+++ b/vertica_python/tests/unit_tests/test_logging.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import logging
 import os

--- a/vertica_python/tests/unit_tests/test_notice.py
+++ b/vertica_python/tests/unit_tests/test_notice.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import mock
 

--- a/vertica_python/tests/unit_tests/test_parsedsn.py
+++ b/vertica_python/tests/unit_tests/test_parsedsn.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .base import VerticaPythonUnitTestCase
 from ...vertica.connection import parse_dsn

--- a/vertica_python/tests/unit_tests/test_sql_literal.py
+++ b/vertica_python/tests/unit_tests/test_sql_literal.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from collections import namedtuple
 from decimal import Decimal

--- a/vertica_python/tests/unit_tests/test_timestamps.py
+++ b/vertica_python/tests/unit_tests/test_timestamps.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from collections import namedtuple
 from datetime import datetime

--- a/vertica_python/vertica/column.py
+++ b/vertica_python/vertica/column.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from typing import TYPE_CHECKING, NamedTuple
 if TYPE_CHECKING:

--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import base64
 import getpass

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import datetime
 import glob

--- a/vertica_python/vertica/deserializer.py
+++ b/vertica_python/vertica/deserializer.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import json
 import re

--- a/vertica_python/vertica/log.py
+++ b/vertica_python/vertica/log.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import logging
 from typing import TYPE_CHECKING

--- a/vertica_python/vertica/messages/__init__.py
+++ b/vertica_python/vertica/messages/__init__.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..messages import backend_messages
 from ..messages.backend_messages import *

--- a/vertica_python/vertica/messages/backend_messages/__init__.py
+++ b/vertica_python/vertica/messages/backend_messages/__init__.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .authentication import Authentication
 from .backend_key_data import BackendKeyData

--- a/vertica_python/vertica/messages/backend_messages/authentication.py
+++ b/vertica_python/vertica/messages/backend_messages/authentication.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack
 

--- a/vertica_python/vertica/messages/backend_messages/backend_key_data.py
+++ b/vertica_python/vertica/messages/backend_messages/backend_key_data.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack
 

--- a/vertica_python/vertica/messages/backend_messages/bind_complete.py
+++ b/vertica_python/vertica/messages/backend_messages/bind_complete.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/close_complete.py
+++ b/vertica_python/vertica/messages/backend_messages/close_complete.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/command_complete.py
+++ b/vertica_python/vertica/messages/backend_messages/command_complete.py
@@ -40,7 +40,7 @@ The server prompt that indicates a command has completed. The command tag
 string is the name of the command that was run.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import re
 import warnings

--- a/vertica_python/vertica/messages/backend_messages/command_description.py
+++ b/vertica_python/vertica/messages/backend_messages/command_description.py
@@ -43,7 +43,7 @@ run this statement instead to achieve better performance when loading many
 batches of parameters.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack
 

--- a/vertica_python/vertica/messages/backend_messages/copy_done_response.py
+++ b/vertica_python/vertica/messages/backend_messages/copy_done_response.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/copy_in_response.py
+++ b/vertica_python/vertica/messages/backend_messages/copy_in_response.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack
 

--- a/vertica_python/vertica/messages/backend_messages/data_row.py
+++ b/vertica_python/vertica/messages/backend_messages/data_row.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack_from
 

--- a/vertica_python/vertica/messages/backend_messages/empty_query_response.py
+++ b/vertica_python/vertica/messages/backend_messages/empty_query_response.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/end_of_batch_response.py
+++ b/vertica_python/vertica/messages/backend_messages/end_of_batch_response.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/error_response.py
+++ b/vertica_python/vertica/messages/backend_messages/error_response.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 from vertica_python.vertica.messages.backend_messages.notice_response import NoticeResponse

--- a/vertica_python/vertica/messages/backend_messages/load_balance_response.py
+++ b/vertica_python/vertica/messages/backend_messages/load_balance_response.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 from struct import unpack

--- a/vertica_python/vertica/messages/backend_messages/load_file.py
+++ b/vertica_python/vertica/messages/backend_messages/load_file.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack
 

--- a/vertica_python/vertica/messages/backend_messages/no_data.py
+++ b/vertica_python/vertica/messages/backend_messages/no_data.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/notice_response.py
+++ b/vertica_python/vertica/messages/backend_messages/notice_response.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack_from
 

--- a/vertica_python/vertica/messages/backend_messages/parameter_description.py
+++ b/vertica_python/vertica/messages/backend_messages/parameter_description.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack, unpack_from, calcsize
 

--- a/vertica_python/vertica/messages/backend_messages/parameter_status.py
+++ b/vertica_python/vertica/messages/backend_messages/parameter_status.py
@@ -50,7 +50,7 @@ simply ignore ParameterStatus for parameters that it does not understand or care
 about.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack
 

--- a/vertica_python/vertica/messages/backend_messages/parse_complete.py
+++ b/vertica_python/vertica/messages/backend_messages/parse_complete.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/portal_suspended.py
+++ b/vertica_python/vertica/messages/backend_messages/portal_suspended.py
@@ -47,7 +47,7 @@ In the future, Vertica may change to restore semantics more similar to those
 intended by Postgres.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/ready_for_query.py
+++ b/vertica_python/vertica/messages/backend_messages/ready_for_query.py
@@ -41,7 +41,7 @@ The ReadyForQuery message is the same one that the backend will issue after each
 command cycle.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack
 

--- a/vertica_python/vertica/messages/backend_messages/row_description.py
+++ b/vertica_python/vertica/messages/backend_messages/row_description.py
@@ -40,7 +40,7 @@ RowDescription message describes the column layout of the rows that will be
 returned in response to a SELECT, FETCH, etc query.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:

--- a/vertica_python/vertica/messages/backend_messages/unknown.py
+++ b/vertica_python/vertica/messages/backend_messages/unknown.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BackendMessage
 

--- a/vertica_python/vertica/messages/backend_messages/verify_files.py
+++ b/vertica_python/vertica/messages/backend_messages/verify_files.py
@@ -23,7 +23,7 @@ The client has to verify that these files exist and are readable
 before running the copy.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack_from
 

--- a/vertica_python/vertica/messages/backend_messages/write_file.py
+++ b/vertica_python/vertica/messages/backend_messages/write_file.py
@@ -24,7 +24,7 @@ RETURNREJECTED parameters instead, this message is a series of row numbers
 saying which rows in the load were rejected.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import unpack_from
 

--- a/vertica_python/vertica/messages/frontend_messages/__init__.py
+++ b/vertica_python/vertica/messages/frontend_messages/__init__.py
@@ -34,7 +34,7 @@
 # THE SOFTWARE.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from .bind import Bind
 from .cancel_request import CancelRequest

--- a/vertica_python/vertica/messages/frontend_messages/bind.py
+++ b/vertica_python/vertica/messages/frontend_messages/bind.py
@@ -42,7 +42,7 @@ to parameter placeholders present in an existing prepared statement.
 The response is either BindComplete or ErrorResponse.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/cancel_request.py
+++ b/vertica_python/vertica/messages/frontend_messages/cancel_request.py
@@ -46,7 +46,7 @@ If the cancellation fails (e.g. the server has finished processing the command),
 then there will be no visible result at all.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/close.py
+++ b/vertica_python/vertica/messages/frontend_messages/close.py
@@ -43,7 +43,7 @@ The response is either CloseComplete or ErrorResponse. It is not an error to
 issue Close against a nonexistent statement or portal name.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/copy_data.py
+++ b/vertica_python/vertica/messages/frontend_messages/copy_data.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BulkFrontendMessage
 

--- a/vertica_python/vertica/messages/frontend_messages/copy_done.py
+++ b/vertica_python/vertica/messages/frontend_messages/copy_done.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BulkFrontendMessage
 

--- a/vertica_python/vertica/messages/frontend_messages/copy_error.py
+++ b/vertica_python/vertica/messages/frontend_messages/copy_error.py
@@ -19,7 +19,7 @@ In the copy-local protocol, the frontend can terminate the cycle by sending a
 CopyError message, which will cause the COPY SQL statement to fail with an error.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/copy_fail.py
+++ b/vertica_python/vertica/messages/frontend_messages/copy_fail.py
@@ -40,7 +40,7 @@ In the copy-in protocol, the frontend can terminate the cycle by sending a
 CopyFail message, which will cause the COPY SQL statement to fail with an error.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/crypt_windows.py
+++ b/vertica_python/vertica/messages/frontend_messages/crypt_windows.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 # Initial permutation
 IP = (

--- a/vertica_python/vertica/messages/frontend_messages/describe.py
+++ b/vertica_python/vertica/messages/frontend_messages/describe.py
@@ -47,7 +47,7 @@ response is a CommandDescription message describing the type of command to be
 executed and any semantically-equivalent COPY statement.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/end_of_batch_request.py
+++ b/vertica_python/vertica/messages/frontend_messages/end_of_batch_request.py
@@ -21,7 +21,7 @@ the frontend is expecting an acknowledgment and possibly rejected row
 descriptions from the backend.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BulkFrontendMessage
 

--- a/vertica_python/vertica/messages/frontend_messages/execute.py
+++ b/vertica_python/vertica/messages/frontend_messages/execute.py
@@ -46,7 +46,7 @@ Currently, Vertica backend will ignore this result-row count and send all the
 rows regardless of what you put here.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/flush.py
+++ b/vertica_python/vertica/messages/frontend_messages/flush.py
@@ -43,7 +43,7 @@ command except Sync, if the frontend wishes to examine the results of that
 command before issuing more commands.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BulkFrontendMessage
 

--- a/vertica_python/vertica/messages/frontend_messages/load_balance_request.py
+++ b/vertica_python/vertica/messages/frontend_messages/load_balance_request.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/parse.py
+++ b/vertica_python/vertica/messages/frontend_messages/parse.py
@@ -46,7 +46,7 @@ error message would be something like
   "Cannot insert multiple commands into a prepared statement"
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/password.py
+++ b/vertica_python/vertica/messages/frontend_messages/password.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import os
 import hashlib

--- a/vertica_python/vertica/messages/frontend_messages/query.py
+++ b/vertica_python/vertica/messages/frontend_messages/query.py
@@ -42,7 +42,7 @@ one or more response messages depending on the contents of the query command
 string, and finally a ReadyForQuery message.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/ssl_request.py
+++ b/vertica_python/vertica/messages/frontend_messages/ssl_request.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from struct import pack
 

--- a/vertica_python/vertica/messages/frontend_messages/startup.py
+++ b/vertica_python/vertica/messages/frontend_messages/startup.py
@@ -40,7 +40,7 @@ To begin a session, the frontend opens a connection to the backend and sends a
 Startup message.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import platform
 import os

--- a/vertica_python/vertica/messages/frontend_messages/sync.py
+++ b/vertica_python/vertica/messages/frontend_messages/sync.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BulkFrontendMessage
 

--- a/vertica_python/vertica/messages/frontend_messages/terminate.py
+++ b/vertica_python/vertica/messages/frontend_messages/terminate.py
@@ -33,7 +33,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from ..message import BulkFrontendMessage
 

--- a/vertica_python/vertica/messages/frontend_messages/verified_files.py
+++ b/vertica_python/vertica/messages/frontend_messages/verified_files.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import os
 from struct import pack

--- a/vertica_python/vertica/messages/message.py
+++ b/vertica_python/vertica/messages/message.py
@@ -50,7 +50,7 @@ going to the backend from Python text string into UTF-8, and to convert data
 coming from the backend from UTF-8 into Python text string.
 """
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from abc import ABCMeta
 from struct import pack

--- a/vertica_python/vertica/mixins/__init__.py
+++ b/vertica_python/vertica/mixins/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations

--- a/vertica_python/vertica/mixins/notice_response_attr.py
+++ b/vertica_python/vertica/mixins/notice_response_attr.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 from collections import OrderedDict
 

--- a/vertica_python/vertica/tlsmode.py
+++ b/vertica_python/vertica/tlsmode.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from __future__ import print_function, division, absolute_import, annotations
+from __future__ import annotations
 
 import ssl
 import warnings


### PR DESCRIPTION
by using Python 3.x annotations in a lot of places, this codebase cannot be possibly Py2.7 compatible anymore