### PR TITLE
do not use as_str, as_bytes in tests

### DIFF
--- a/vertica_python/tests/common/base.py
+++ b/vertica_python/tests/common/base.py
@@ -43,7 +43,6 @@ import inspect
 import getpass
 from configparser import ConfigParser
 
-from ...compat import as_str, as_bytes
 from ...vertica.log import VerticaLogging
 
 
@@ -128,22 +127,6 @@ class VerticaPythonTestCase(unittest.TestCase):
         self.logger.info('\n'+'-'*10+' End '+self.__class__.__name__+"."+self._testMethodName+' '+'-'*10+'\n')
 
     # Common assertions
-    def assertStrEqual(self, first, second, msg=None):
-        first_str = as_str(first)
-        second_str = as_str(second)
-        self.assertEqual(first=first_str, second=second_str, msg=msg)
-
-    def assertBytesEqual(self, first, second, msg=None):
-        first_bytes = as_bytes(first)
-        second_bytes = as_bytes(second)
-        self.assertEqual(first=first_bytes, second=second_bytes, msg=msg)
-
-    def assertResultEqual(self, value, result, msg=None):
-        if isinstance(value, str):
-            self.assertStrEqual(first=value, second=result, msg=msg)
-        else:
-            self.assertEqual(first=value, second=result, msg=msg)
-
     def assertListOfListsEqual(self, list1, list2, msg=None):
         self.assertEqual(len(list1), len(list2), msg=msg)
         for l1, l2 in zip(list1, list2):

--- a/vertica_python/tests/integration_tests/test_unicode.py
+++ b/vertica_python/tests/integration_tests/test_unicode.py
@@ -48,7 +48,7 @@ class UnicodeTestCase(VerticaPythonIntegrationTestCase):
             cur.execute(query)
             res = cur.fetchone()
 
-        self.assertResultEqual(value, res[0])
+        self.assertEqual(value, res[0])
 
     def test_unicode_list_parameter(self):
         values = ['\u00f1', 'foo', 3]
@@ -60,7 +60,7 @@ class UnicodeTestCase(VerticaPythonIntegrationTestCase):
             results = cur.fetchone()
 
         for val, res in zip(values, results):
-            self.assertResultEqual(val, res)
+            self.assertEqual(val, res)
 
     def test_unicode_named_parameter_binding(self):
         values = ['\u16b1', 'foo', 3]
@@ -74,7 +74,7 @@ class UnicodeTestCase(VerticaPythonIntegrationTestCase):
             results = cur.fetchone()
 
         for val, res in zip(values, results):
-            self.assertResultEqual(val, res)
+            self.assertEqual(val, res)
 
     def test_string_query(self):
         value = 'test'
@@ -97,7 +97,7 @@ class UnicodeTestCase(VerticaPythonIntegrationTestCase):
             cur.execute(query, {key: value})
             res = cur.fetchone()
 
-        self.assertResultEqual(value, res[0])
+        self.assertEqual(value, res[0])
 
     # unit test for issue #160
     def test_null_named_parameter_binding(self):
@@ -110,7 +110,7 @@ class UnicodeTestCase(VerticaPythonIntegrationTestCase):
             cur.execute(query, {key: value})
             res = cur.fetchone()
 
-        self.assertResultEqual(value, res[0])
+        self.assertEqual(value, res[0])
 
     # unit test for issue #160
     def test_null_list_parameter(self):
@@ -123,4 +123,4 @@ class UnicodeTestCase(VerticaPythonIntegrationTestCase):
             results = cur.fetchone()
 
         for val, res in zip(values, results):
-            self.assertResultEqual(val, res)
+            self.assertEqual(val, res)


### PR DESCRIPTION
they might remain usefull is users call this library with wrong parameters type