### PR TITLE
Fix tls response when socket is closed by server

### DIFF
--- a/vertica_python/vertica/connection.py
+++ b/vertica_python/vertica/connection.py
@@ -606,6 +606,10 @@ class Connection:
         raw_socket.sendall(messages.SslRequest().get_message())
         response = raw_socket.recv(1)
         self._logger.debug('<= SslResponse: %s', response)
+        if response == b'':
+            msg = 'Failed to get ssl response from server'
+            self._logger.error(msg)
+            raise errors.ConnectionError(msg)
         if response == b'S':
             self._logger.info('Enabling TLS')
             try:


### PR DESCRIPTION
When client sends a ssl request and waiting for a ssl response, the socket may be closed by server and the response would be an empty byte `b''`, the client need to handle this case.