### PR TITLE
Fix issue with client-server out-of-sync in case of permission error …

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,5 @@ pytest
 pytest-timeout
 python-dateutil
 tox
+parameterized
 #kerberos

--- a/vertica_python/tests/integration_tests/base.py
+++ b/vertica_python/tests/integration_tests/base.py
@@ -94,6 +94,17 @@ class VerticaPythonIntegrationTestCase(VerticaPythonTestCase):
         return connect(**cls._conn_info)
 
     @classmethod
+    def _connect_user_pass(cls, user: str, password: str):
+        """Connects to vertica with an overridden user/pass.
+
+        :return: a connection to vertica.
+        """
+        conn_info = cls._conn_info.copy()
+        conn_info['user'] = user
+        conn_info['password'] = password
+        return connect(**conn_info)
+
+    @classmethod
     def _get_node_num(cls):
         """Executes a query to get the number of nodes in the database
 

--- a/vertica_python/tests/integration_tests/test_cursor.py
+++ b/vertica_python/tests/integration_tests/test_cursor.py
@@ -1193,6 +1193,8 @@ class PreparedStatementTestCase(VerticaPythonIntegrationTestCase):
     def setUp(self):
         super(PreparedStatementTestCase, self).setUp()
         self._table = 'preparedstmt_test'
+        self._user = 'test_user'
+        self._password = 'TestPassword123'
         with self._connect() as conn:
             cur = conn.cursor()
             cur.execute("DROP TABLE IF EXISTS {0}".format(self._table))
@@ -1472,3 +1474,27 @@ class PreparedStatementTestCase(VerticaPythonIntegrationTestCase):
 
             self.assertEqual(cur.description[0].display_size, 10000)
             self.assertEqual(cur.description[1].display_size, 1000)
+
+    def test_multiple_permission_error(self):
+        with self._connect() as conn:
+            try:
+                cur = conn.cursor()
+                cur.execute("CREATE TABLE {} (id INT)"
+                            .format(self._table))
+
+                try:
+                    cur.execute("CREATE USER {} IDENTIFIED BY '{}'".format(self._user, self._password), use_prepared_statements=False)
+                except errors.QueryError:
+                    pass  # User already exists
+                conn.commit()
+
+                with self._connect_user_pass(self._user, self._password) as conn_2:
+                    cur_2 = conn_2.cursor()
+                    for i in range(1, 5):
+                        with pytest.raises(errors.DatabaseError, match='Permission denied for relation {}'.format(self._table)):
+                            cur_2.execute("SELECT * FROM {} LIMIT 1".format(self._table))
+            finally:
+                try:
+                    cur.execute("DROP USER {}".format(self._user))
+                except errors.QueryError:
+                    pass  # User did not exist

--- a/vertica_python/vertica/cursor.py
+++ b/vertica_python/vertica/cursor.py
@@ -945,6 +945,10 @@ class Cursor:
         self.connection.write(messages.Sync())
         raise errors.QueryError.from_error_response(msg, self.operation)
 
+    def _prepared_statement_error_handler(self, msg: BackendMessage) -> NoReturn:
+        self._message = msg
+        raise errors.DatabaseError(msg.error_message())
+
     def _prepare(self, query: str) -> None:
         """
         Send the query to be prepared to the server. The server will parse the
@@ -1024,7 +1028,7 @@ class Cursor:
         self.connection.write(messages.Flush())
 
         # Read expected message: BindComplete
-        self.connection.read_expected_message(messages.BindComplete)
+        self.connection.read_expected_message(messages.BindComplete, self._prepared_statement_error_handler)
 
         self._message = self.connection.read_message()
         if isinstance(self._message, messages.ErrorResponse):


### PR DESCRIPTION
Fixes bug (#579)

It seems that the vertica client had an issue consuming ReadyForQuery messages when prepared statements are used and several consecutive queries are rejected with permission error.

Faulty sequence of messages:
```
2026-02-14 00:26:48.116 [cursor] 2563516822224/13328:0x6a80 <INFO> Bind parameters: ()
2026-02-14 00:26:48.117 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Bind
2026-02-14 00:26:48.117 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Execute
2026-02-14 00:26:48.118 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Sync
2026-02-14 00:26:48.118 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Flush
2026-02-14 00:26:48.119 [connection] 2563516822224/13328:0x6a80 <DEBUG> <= ErrorResponse: Severity: ERROR, Message: Permission denied for relation preparedstmt_test, Sqlstate: 42501, Routine: report_no_priv, File: /data/jenkins/workspace/RE-ReleaseBuilds/RE-Miner/server/vertica/Commands/GrantRevoke.cpp, Line: 532, Error Code: 4367
2026-02-14 00:26:48.119 [connection] 2563516822224/13328:0x6a80 <DEBUG> <= ReadyForQuery: status = in_transaction
2026-02-14 00:26:48.119 [cursor] 2563516822224/13328:0x6a80 <INFO> Bind parameters: ()
2026-02-14 00:26:48.119 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Bind
2026-02-14 00:26:48.120 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Execute
2026-02-14 00:26:48.120 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Sync
2026-02-14 00:26:48.120 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Flush
2026-02-14 00:26:48.121 [connection] 2563516822224/13328:0x6a80 <DEBUG> <= ErrorResponse: Severity: ERROR, Message: Permission denied for relation preparedstmt_test, Sqlstate: 42501, Routine: report_no_priv, File: /data/jenkins/workspace/RE-ReleaseBuilds/RE-Miner/server/vertica/Commands/GrantRevoke.cpp, Line: 532, Error Code: 4367
2026-02-14 00:26:48.122 [cursor] 2563516822224/13328:0x6a80 <INFO> Bind parameters: ()
2026-02-14 00:26:48.122 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Bind
2026-02-14 00:26:48.122 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Execute
2026-02-14 00:26:48.122 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Sync
2026-02-14 00:26:48.123 [connection] 2563516822224/13328:0x6a80 <DEBUG> => Flush
2026-02-14 00:26:48.123 [connection] 2563516822224/13328:0x6a80 <DEBUG> <= ReadyForQuery: status = in_transaction
```

It seems that when a permission denied error is happening then the server replies with ErrorResponse and ReadyForQuery.

First attempt:
- self._message in cursor.py is None
- trying to read BindComplete in _execute_prepared_statement() but ErrorResponse is found -> self._message in cursor.py is sill None
- ReadyForQuery after ErrorResponse is not consumed

Second attempt:
- self._message in cursor.py is None
- ReadyForQuery in buffer is consumed in execute() and stored to self._message
- trying to read BindComplete in _execute_prepared_statement() but ErrorResponse is found -> self._message in cursor.py is now ReadyForQuery
- ReadyForQuery after ErrorResponse is not consumed

Third attempt:
- self._message in cursor.py is ReadyForQuery
- ReadyForQuery is not consumed in execute() because self._message is ReadyForQuery
- trying to read BindComplete in _execute_prepared_statement() but ReadyForQuery is found -> raising this anomaly as an exception

This fix introduces an error handler for the prepared statement execution to always set the ErrorResponse as self._message to make it possible for the flush_to_query_ready() in execute() to consume and store ReadyForQuery
Also integration test is added.